### PR TITLE
Removes all Thread.sleep() calls.

### DIFF
--- a/osgp-platform-test/pom.xml
+++ b/osgp-platform-test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.alliander.osgp</groupId>
         <artifactId>parent-integration-tests</artifactId>
-        <version>0.11.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../parent-integration-tests/pom.xml</relativePath>
     </parent>
 

--- a/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/adhocmanagement/SetRebootSteps.java
+++ b/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/adhocmanagement/SetRebootSteps.java
@@ -263,14 +263,7 @@ public class SetRebootSteps {
         LOGGER.info("WHEN: \"the set reboot request is received\".");
 
         try {
-
             this.setRebootAsyncResponse = this.adHocManagementEndpoint.setReboot(ORGANISATION_ID, this.request);
-
-            // Add sleep to enable queue processing
-            for (int i = 0; i < 1000; i++) {
-                Thread.sleep(1);
-            }
-
         } catch (final Throwable t) {
             LOGGER.error("Exception [{}]: {}", t.getClass().getSimpleName(), t.getMessage());
             this.throwable = t;
@@ -367,7 +360,7 @@ public class SetRebootSteps {
 
         try {
             final ArgumentCaptor<OslpEnvelope> argument = ArgumentCaptor.forClass(OslpEnvelope.class);
-            verify(this.channelMock, timeout(1000).times(count)).write(argument.capture());
+            verify(this.channelMock, timeout(10000).times(count)).write(argument.capture());
 
             if (isMessageSent) {
                 this.oslpResponse = argument.getValue();

--- a/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/adhocmanagement/SetTransitionSteps.java
+++ b/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/adhocmanagement/SetTransitionSteps.java
@@ -9,7 +9,7 @@ package com.alliander.osgp.acceptancetests.adhocmanagement;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -207,7 +207,7 @@ public class SetTransitionSteps {
         authorizations.add(new DeviceAuthorizationBuilder().withDevice(this.device).withOrganisation(this.organisation)
                 .withFunctionGroup(DeviceFunctionGroup.AD_HOC).build());
         when(this.deviceAuthorizationRepositoryMock.findByOrganisationAndDevice(this.organisation, this.device))
-                .thenReturn(authorizations);
+        .thenReturn(authorizations);
     }
 
     // === WHEN ===
@@ -217,12 +217,6 @@ public class SetTransitionSteps {
 
         try {
             this.setTransitionAsyncResponse = this.adHocManagementEndpoint.setTransition(ORGANISATION_ID, this.request);
-
-            // Add sleep to enable queue processing
-            for (int i = 0; i < 1000; i++) {
-                Thread.sleep(1);
-            }
-
         } catch (final Throwable t) {
             LOGGER.error("Exception [{}]: {}", t.getClass().getSimpleName(), t.getMessage());
             this.throwable = t;
@@ -261,7 +255,7 @@ public class SetTransitionSteps {
 
         try {
             final ArgumentCaptor<OslpEnvelope> argument = ArgumentCaptor.forClass(OslpEnvelope.class);
-            verify(this.channelMock, times(count)).write(argument.capture());
+            verify(this.channelMock, timeout(10000).times(count)).write(argument.capture());
 
             if (isMessageSent) {
                 this.oslpRequest = argument.getValue();
@@ -285,7 +279,7 @@ public class SetTransitionSteps {
 
         try {
             final ArgumentCaptor<ResponseMessage> argument = ArgumentCaptor.forClass(ResponseMessage.class);
-            verify(this.webServiceResponseMessageSenderMock, times(1)).send(argument.capture());
+            verify(this.webServiceResponseMessageSenderMock, timeout(10000).times(1)).send(argument.capture());
 
             final String expected = result.equals("NULL") ? null : result;
             final String actual = argument.getValue().getResult().getValue();
@@ -307,7 +301,7 @@ public class SetTransitionSteps {
 
         try {
             final ArgumentCaptor<OslpEnvelope> argument = ArgumentCaptor.forClass(OslpEnvelope.class);
-            verify(this.channelMock, times(count)).write(argument.capture());
+            verify(this.channelMock, timeout(10000).times(count)).write(argument.capture());
 
             if (isMessageSent) {
                 this.oslpRequest = argument.getValue();
@@ -405,7 +399,6 @@ public class SetTransitionSteps {
         LOGGER.info("WHEN: \"the set transition request is received\".");
 
         try {
-
             this.response = this.adHocManagementEndpoint.getSetTransitionResponse(ORGANISATION_ID,
                     this.setTransitionAsyncRequest);
 
@@ -450,8 +443,8 @@ public class SetTransitionSteps {
     // === Private methods ===
     private void setUp() {
         Mockito.reset(new Object[] { this.deviceRepositoryMock, this.organisationRepositoryMock,
-                this.deviceAuthorizationRepositoryMock, this.deviceLogItemRepositoryMock, this.oslpDeviceRepositoryMock,
-                this.webServiceResponseMessageSenderMock, this.channelMock });
+                this.deviceAuthorizationRepositoryMock, this.deviceLogItemRepositoryMock,
+                this.oslpDeviceRepositoryMock, this.webServiceResponseMessageSenderMock, this.channelMock });
 
         this.adHocManagementEndpoint = new PublicLightingAdHocManagementEndpoint(this.adHocManagementService,
                 new AdHocManagementMapper());

--- a/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/deviceinstallation/RegisterDeviceSteps.java
+++ b/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/deviceinstallation/RegisterDeviceSteps.java
@@ -9,8 +9,7 @@ package com.alliander.osgp.acceptancetests.deviceinstallation;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -167,7 +166,7 @@ public class RegisterDeviceSteps {
     // === GIVEN ===
     @DomainStep("a valid register device OSLP message")
     public void givenAValidRegisterDeviceRequest() throws NoSuchAlgorithmException, InvalidKeySpecException,
-            IOException {
+    IOException {
         LOGGER.info("GIVEN: \"a valid register device OSLP message\".");
 
         this.setup();
@@ -254,8 +253,6 @@ public class RegisterDeviceSteps {
         try {
             this.oslpSecurityHandler.messageReceived(this.channelHandlerContextMock, this.messageEvent);
             this.oslpChannelHandler.messageReceived(this.channelHandlerContextMock, this.messageEvent);
-
-            Thread.sleep(250);
         } catch (final Throwable t) {
             LOGGER.error("Caught exception: {}", t);
         }
@@ -267,8 +264,8 @@ public class RegisterDeviceSteps {
         LOGGER.info("THEN: \"the device should be updated with new deviceUID, IP address and device type\".");
 
         try {
-            verify(this.oslpDeviceRepositoryMock, atLeastOnce()).save(any(OslpDevice.class));
-            verify(this.deviceRepositoryMock, atLeastOnce()).save(any(Device.class));
+            verify(this.oslpDeviceRepositoryMock, timeout(10000).atLeastOnce()).save(any(OslpDevice.class));
+            verify(this.deviceRepositoryMock, timeout(10000).atLeastOnce()).save(any(Device.class));
         } catch (final Throwable t) {
             LOGGER.error("Failure: {}", t);
             return false;
@@ -284,7 +281,7 @@ public class RegisterDeviceSteps {
                 .ofDeviceType(DeviceType.SSLD.toString()).build();
 
         try {
-            verify(this.deviceRepositoryMock, times(1)).save(eq(expectedDevice));
+            verify(this.deviceRepositoryMock, timeout(10000).times(1)).save(eq(expectedDevice));
         } catch (final Throwable t) {
             LOGGER.error("Failure: {}", t);
             return false;
@@ -296,7 +293,7 @@ public class RegisterDeviceSteps {
     public boolean thenTheDeviceShouldNotBeCreated() {
         LOGGER.info("THEN: \"the device should not be created for security reasons\".");
         try {
-            verify(this.deviceRepositoryMock, times(0)).save(any(Device.class));
+            verify(this.deviceRepositoryMock, timeout(10000).times(0)).save(any(Device.class));
         } catch (final Throwable t) {
             LOGGER.error("Failure: {}", t);
             return false;
@@ -309,7 +306,7 @@ public class RegisterDeviceSteps {
         LOGGER.info("THEN: \"the network address for the other device should be cleared\".");
         try {
             Assert.assertNull(this.anotherDevice.getNetworkAddress());
-            verify(this.deviceRepositoryMock, times(1)).save(eq(this.anotherDevice));
+            verify(this.deviceRepositoryMock, timeout(10000).times(1)).save(eq(this.anotherDevice));
         } catch (final Throwable t) {
             LOGGER.error("Failure: {}", t);
             return false;
@@ -326,7 +323,7 @@ public class RegisterDeviceSteps {
         final ArgumentCaptor<OslpEnvelope> responseCaptor = ArgumentCaptor.forClass(OslpEnvelope.class);
 
         try {
-            verify(this.channelMock, times(1)).write(responseCaptor.capture());
+            verify(this.channelMock, timeout(10000).times(1)).write(responseCaptor.capture());
         } catch (final Throwable t) {
             LOGGER.error("Failure: {}", t);
             return false;
@@ -346,7 +343,7 @@ public class RegisterDeviceSteps {
         LOGGER.info("THEN: \"the register device request should not return a response\".");
 
         try {
-            verify(this.channelMock, times(0)).write(any(Device.class));
+            verify(this.channelMock, timeout(10000).times(0)).write(any(Device.class));
         } catch (final Throwable t) {
             LOGGER.error("Failure: {}", t);
             return false;

--- a/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/devicemanagement/UpdateKeySteps.java
+++ b/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/devicemanagement/UpdateKeySteps.java
@@ -214,7 +214,7 @@ public class UpdateKeySteps {
         LOGGER.info("THEN: \"the device {} should not be updated with the invalid key {}\".", device, key);
 
         try {
-            verify(this.deviceRepositoryMock, timeout(10000).times(0)).save(any(Device.class));
+            verify(this.oslpDeviceRepositoryMock, timeout(10000).times(0)).save(any(OslpDevice.class));
         } catch (final Throwable t) {
             LOGGER.error("Exception [{}]: {}", t.getClass().getSimpleName(), t.getMessage());
             return false;

--- a/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/devicemanagement/UpdateKeySteps.java
+++ b/osgp-platform-test/src/test/java/com/alliander/osgp/acceptancetests/devicemanagement/UpdateKeySteps.java
@@ -93,7 +93,6 @@ public class UpdateKeySteps {
         this.throwable = null;
         this.request = null;
         this.response = null;
-
     }
 
     // === GIVEN ===
@@ -130,9 +129,9 @@ public class UpdateKeySteps {
                 .withProtocolInfo(ProtocolInfoTestUtils.getProtocolInfo(PROTOCOL, PROTOCOL_VERSION)).build();
         this.oslpDevice = new OslpDeviceBuilder().withDeviceIdentification(device).build();
 
-        when(this.deviceRepositoryMock.findByDeviceIdentification(device)).thenReturn(null, this.device);
+        when(this.deviceRepositoryMock.findByDeviceIdentification(device)).thenReturn(this.device);
         when(this.oslpDeviceRepositoryMock.save(any(OslpDevice.class))).thenReturn(this.oslpDevice);
-        when(this.oslpDeviceRepositoryMock.findByDeviceIdentification(device)).thenReturn(null, this.oslpDevice);
+        when(this.oslpDeviceRepositoryMock.findByDeviceIdentification(device)).thenReturn(this.oslpDevice);
     }
 
     @DomainStep("the update key request refers to an existing organisation that is authorized")
@@ -160,9 +159,6 @@ public class UpdateKeySteps {
 
         try {
             this.response = this.deviceManagementEndpoint.updateKey(ORGANISATION_ID, this.request);
-
-            Thread.sleep(1000);
-
         } catch (final Throwable t) {
             LOGGER.error("Exception [{}]: {}", t.getClass().getSimpleName(), t.getMessage());
             this.throwable = t;
@@ -199,7 +195,7 @@ public class UpdateKeySteps {
         try {
             final ArgumentCaptor<OslpDevice> argument = ArgumentCaptor.forClass(OslpDevice.class);
 
-            verify(this.oslpDeviceRepositoryMock, timeout(10000).times(2)).save(argument.capture());
+            verify(this.oslpDeviceRepositoryMock, timeout(10000).times(1)).save(argument.capture());
 
             Assert.assertEquals("Device identifications should match", device, argument.getValue()
                     .getDeviceIdentification());


### PR DESCRIPTION
- This should improve reliability of the test suite
- It could save time when running the test suite
- The sleep() calls cause some SonarQube issues