### PR TITLE
Removed duplicate teststep without implementation.

### DIFF
--- a/cucumber-tests-platform-dlms/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringInstallation.feature
+++ b/cucumber-tests-platform-dlms/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringInstallation.feature
@@ -20,4 +20,4 @@ Feature: SmartMetering Installation
     And receiving an get add device response request
       | DeviceIdentification | E0026000059790003 |
     And the get add device request response should be ok
-    And the device with the id "E0026000059790003" exists
+    And the dlms device with id "E0026000059790003" exists

--- a/cucumber-tests-platform-dlms/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringInstallation.feature
+++ b/cucumber-tests-platform-dlms/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringInstallation.feature
@@ -21,4 +21,3 @@ Feature: SmartMetering Installation
       | DeviceIdentification | E0026000059790003 |
     And the get add device request response should be ok
     And the device with the id "E0026000059790003" exists
-    And the dlms device with id "E0026000059790003" exists

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/platform/cucumber/steps/database/core/DeviceSteps.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/platform/cucumber/steps/database/core/DeviceSteps.java
@@ -299,8 +299,8 @@ public class DeviceSteps {
      * @param deviceIdentification
      * @return
      */
-    @Then("^the device with the id \"([^\"]*)\" exists$")
-    public void theDeviceWithIdExists(final String deviceIdentification) throws Throwable {
+    @Then("^the dlms device with id \"([^\"]*)\" exists$")
+    public void theDlmsDeviceWithIdExists(final String deviceIdentification) throws Throwable {
         final Device device = this.deviceRepository.findByDeviceIdentification(deviceIdentification);
         final List<DeviceAuthorization> devAuths = this.deviceAuthorizationRepository.findByDevice(device);
 


### PR DESCRIPTION
The Scenario Add a new device has a duplicate teststep with different syntax. One of them was not implemented and caused a skipped test step.