### PR TITLE
SLIM-908 Configures HikariDataSource for tests

### DIFF
--- a/cucumber-tests-platform-dlms/src/test/java/com/alliander/osgp/cucumber/platform/dlms/support/ResponseNotifierImpl.java
+++ b/cucumber-tests-platform-dlms/src/test/java/com/alliander/osgp/cucumber/platform/dlms/support/ResponseNotifierImpl.java
@@ -7,21 +7,17 @@
  */
 package com.alliander.osgp.cucumber.platform.dlms.support;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import com.alliander.osgp.adapter.ws.smartmetering.domain.entities.MeterResponseData;
+import com.alliander.osgp.adapter.ws.smartmetering.domain.repositories.MeterResponseDataRepository;
 import com.alliander.osgp.logging.domain.entities.DeviceLogItem;
 import com.alliander.osgp.logging.domain.repositories.DeviceLogItemRepository;
 
@@ -34,171 +30,101 @@ public class ResponseNotifierImpl implements ResponseNotifier {
 
     private static final int FIRST_WAIT_TIME = 1000;
 
-    private Connection connection;
-
     @Autowired
     private DeviceLogItemRepository deviceLogItemRepository;
 
-    @Value("${osgpadapterwssmartmeteringdbs.url}")
-    private String jdbcUrlOsgpAdapterWsSmartmetering;
-
-    @Value("${osgploggingdbs.url}")
-    private String jdbcUrlOsgpLogging;
-
-    @Value("${db.username}")
-    private String username;
-
-    @Value("${db.password}")
-    private String password;
+    @Autowired
+    private MeterResponseDataRepository meterResponseDataRepository;
 
     @Override
-    public boolean waitForResponse(final String correlid, final int timeout, final int maxtime) {
-        Statement statement = null;
-        try {
-            statement = this.conn(this.jdbcUrlOsgpAdapterWsSmartmetering).createStatement();
+    public boolean waitForResponse(final String correlationUid, final int timeout, final int maxtime) {
 
+        try {
             // check if we have (almost) immediate response
             Thread.sleep(FIRST_WAIT_TIME);
-            PollResult pollres = this.pollDatabase(statement, correlid);
-            if (pollres.equals(PollResult.OK)) {
-                return true;
-            }
+            PollResult pollResult = this.pollMeterResponseDatabase(correlationUid);
 
-            int delayedtime = 0;
+            int delayedTime = 0;
             while (true) {
-                Thread.sleep(timeout);
-                if ((delayedtime += timeout) < maxtime) {
-                    pollres = this.pollDatabase(statement, correlid);
-                    if (pollres.equals(PollResult.OK)) {
-                        return true;
-                    } else if (pollres.equals(PollResult.ERROR)) {
+                switch (pollResult) {
+                case OK:
+                    return true;
+                case ERROR:
+                    return false;
+                case NOT_OK:
+                    delayedTime += timeout;
+                    if (delayedTime > maxtime) {
                         return false;
                     }
-                } else {
-                    return false;
                 }
+                Thread.sleep(timeout);
+                pollResult = this.pollMeterResponseDatabase(correlationUid);
             }
-        } catch (final SQLException se) {
-            LOGGER.error(se.getMessage());
+        } catch (final InterruptedException e) {
+            LOGGER.error("Unexpected exception waiting for response", e);
             return false;
-        } catch (final InterruptedException intex) {
-            LOGGER.error(intex.getMessage());
-            return false;
-        } finally {
-            this.closeStatement(statement);
         }
     }
 
     @Override
     public boolean waitForLog(final String deviceId, final int timeout, final int maxtime) {
-        Statement statement = null;
-        try {
-            statement = this.conn(this.jdbcUrlOsgpLogging).createStatement();
 
+        try {
             // check if we have (almost) immediate response
             Thread.sleep(FIRST_WAIT_TIME);
-            PollResult pollres = this.pollLogDatabase(statement, deviceId);
-            if (pollres.equals(PollResult.OK)) {
-                return true;
-            }
+            PollResult pollResult = this.pollLogDatabase(deviceId);
 
-            int delayedtime = 0;
+            int delayedTime = 0;
             while (true) {
-                Thread.sleep(timeout);
-                if ((delayedtime += timeout) < maxtime) {
-                    pollres = this.pollLogDatabase(statement, deviceId);
-                    if (pollres.equals(PollResult.OK)) {
-                        return true;
-                    } else if (pollres.equals(PollResult.ERROR)) {
+                switch (pollResult) {
+                case OK:
+                    return true;
+                case ERROR:
+                    return false;
+                case NOT_OK:
+                    delayedTime += timeout;
+                    if (delayedTime > maxtime) {
                         return false;
                     }
-                } else {
-                    return false;
                 }
+                Thread.sleep(timeout);
+                pollResult = this.pollLogDatabase(deviceId);
             }
-        } catch (final SQLException se) {
-            LOGGER.error(se.getMessage());
+        } catch (final InterruptedException e) {
+            LOGGER.error("Unexpected exception waiting for response", e);
             return false;
-        } catch (final InterruptedException intex) {
-            LOGGER.error(intex.getMessage());
-            return false;
-        } finally {
-            this.closeStatement(statement);
         }
     }
 
-    private PollResult pollDatabase(final Statement statement, final String correlid) {
-        ResultSet rs = null;
+    private PollResult pollMeterResponseDatabase(final String correlationUid) {
+        PollResult pollResult = PollResult.NOT_OK;
+        try {
+            final List<MeterResponseData> meterResponseDataByCorrelationUid = this.meterResponseDataRepository
+                    .findByCorrelationUid(correlationUid);
+            if (!meterResponseDataByCorrelationUid.isEmpty()) {
+                pollResult = PollResult.OK;
+            }
+        } catch (final Exception e) {
+            LOGGER.error("Error polling MeterResponseData for correlationUid {}", correlationUid, e);
+            pollResult = PollResult.ERROR;
+        }
+        return pollResult;
+    }
+
+    private PollResult pollLogDatabase(final String deviceId) {
         PollResult result = PollResult.NOT_OK;
         try {
-            rs = statement.executeQuery(
-                    "SELECT count(*) FROM meter_response_data WHERE correlation_uid = '" + correlid + "'");
-            while (rs.next()) {
-                if (rs.getInt(1) > 0) {
-                    result = PollResult.OK;
-                }
+            final List<DeviceLogItem> deviceLogItems = this.deviceLogItemRepository
+                    .findByDeviceIdentification(deviceId, new PageRequest(0, 2)).getContent();
+
+            if (deviceLogItems != null && deviceLogItems.size() > 1) {
+                result = PollResult.OK;
             }
-            return result;
-        } catch (final SQLException se) {
-            LOGGER.error(se.getMessage());
-            return PollResult.ERROR;
-        } finally {
-            this.closeResultSet(rs);
-        }
-    }
-
-    private PollResult pollLogDatabase(final Statement statement, final String deviceId) {
-        PollResult result = PollResult.NOT_OK;
-
-        final List<DeviceLogItem> deviceLogItems = this.deviceLogItemRepository
-                .findByDeviceIdentification(deviceId, new PageRequest(0, 2)).getContent();
-
-        if (deviceLogItems != null && deviceLogItems.size() > 1) {
-            result = PollResult.OK;
+        } catch (final Exception e) {
+            LOGGER.error("Error polling LogData for device identification {}", deviceId, e);
+            result = PollResult.ERROR;
         }
         return result;
-    }
-
-    private void closeStatement(final Statement statement) {
-        if (statement != null) {
-            try {
-                statement.close();
-            } catch (final SQLException e) {
-                LOGGER.error(e.getMessage());
-            }
-        }
-    }
-
-    private void closeResultSet(final ResultSet rs) {
-        if (rs == null) {
-            return;
-        }
-        try {
-            rs.close();
-        } catch (final SQLException e) {
-            LOGGER.error(e.getMessage());
-        }
-    }
-
-    private Connection conn(final String dbUrl) {
-        if (this.connection == null) {
-            this.connection = this.connectToDatabaseOrDie(dbUrl);
-        }
-        return this.connection;
-    }
-
-    private Connection connectToDatabaseOrDie(final String dbUrl) {
-        try {
-            Class.forName("org.postgresql.Driver");
-            this.connection = DriverManager.getConnection(dbUrl, this.username, this.password);
-        } catch (final ClassNotFoundException e) {
-            LOGGER.error(e.getMessage());
-            System.exit(1);
-        } catch (final SQLException e) {
-            LOGGER.error(e.getMessage());
-            System.exit(2);
-        }
-        return this.connection;
     }
 
     private enum PollResult {

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolDlmsPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolDlmsPersistenceConfig.java
@@ -30,20 +30,12 @@ public class AdapterProtocolDlmsPersistenceConfig extends ApplicationPersistence
     @Value("${db.name.osgp_adapter_protocol_dlms}")
     private String databaseName;
 
-    @Value("${osgpadapterprotocoldlmsdbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan.dlms}")
     private String entitymanagerPackagesToScan;
 
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolDlmsPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolDlmsPersistenceConfig.java
@@ -27,11 +27,19 @@ public class AdapterProtocolDlmsPersistenceConfig extends ApplicationPersistence
     public AdapterProtocolDlmsPersistenceConfig() {
     }
 
+    @Value("${db.name.osgp_adapter_protocol_dlms}")
+    private String databaseName;
+
     @Value("${osgpadapterprotocoldlmsdbs.url}")
     private String databaseUrl;
 
     @Value("${entitymanager.packages.to.scan.dlms}")
     private String entitymanagerPackagesToScan;
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
+    }
 
     @Override
     protected String getDatabaseUrl() {

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolIec61850PersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolIec61850PersistenceConfig.java
@@ -28,11 +28,19 @@ public class AdapterProtocolIec61850PersistenceConfig extends ApplicationPersist
     public AdapterProtocolIec61850PersistenceConfig() {
     }
 
+    @Value("${db.name.osgp_adapter_protocol_iec61850}")
+    private String databaseName;
+
     @Value("${osgpadapterprotocoliec61850dbs.url}")
     private String databaseUrl;
 
     @Value("${entitymanager.packages.to.scan.iec61850}")
     private String entitymanagerPackagesToScan;
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
+    }
 
     @Override
     protected String getDatabaseUrl() {

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolIec61850PersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolIec61850PersistenceConfig.java
@@ -31,20 +31,12 @@ public class AdapterProtocolIec61850PersistenceConfig extends ApplicationPersist
     @Value("${db.name.osgp_adapter_protocol_iec61850}")
     private String databaseName;
 
-    @Value("${osgpadapterprotocoliec61850dbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan.iec61850}")
     private String entitymanagerPackagesToScan;
 
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolOslpPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolOslpPersistenceConfig.java
@@ -32,20 +32,12 @@ public class AdapterProtocolOslpPersistenceConfig extends ApplicationPersistence
     @Value("${db.name.osgp_adapter_protocol_oslp}")
     private String databaseName;
 
-    @Value("${osgpadapterprotocoloslpdbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan.oslp}")
     private String entitymanagerPackagesToScan;
 
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolOslpPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterProtocolOslpPersistenceConfig.java
@@ -29,11 +29,19 @@ public class AdapterProtocolOslpPersistenceConfig extends ApplicationPersistence
     public AdapterProtocolOslpPersistenceConfig() {
     }
 
+    @Value("${db.name.osgp_adapter_protocol_oslp}")
+    private String databaseName;
+
     @Value("${osgpadapterprotocoloslpdbs.url}")
     private String databaseUrl;
 
     @Value("${entitymanager.packages.to.scan.oslp}")
     private String entitymanagerPackagesToScan;
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
+    }
 
     @Override
     protected String getDatabaseUrl() {

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsMicrogridsPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsMicrogridsPersistenceConfig.java
@@ -31,20 +31,12 @@ public class AdapterWsMicrogridsPersistenceConfig extends ApplicationPersistence
     @Value("${db.name.osgp_adapter_ws_microgrids}")
     private String databaseName;
 
-    @Value("${osgpadapterwsmicrogridsdbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan.ws.microgrids}")
     private String entitymanagerPackagesToScan;
 
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsMicrogridsPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsMicrogridsPersistenceConfig.java
@@ -28,11 +28,19 @@ public class AdapterWsMicrogridsPersistenceConfig extends ApplicationPersistence
     public AdapterWsMicrogridsPersistenceConfig() {
     }
 
+    @Value("${db.name.osgp_adapter_ws_microgrids}")
+    private String databaseName;
+
     @Value("${osgpadapterwsmicrogridsdbs.url}")
     private String databaseUrl;
 
     @Value("${entitymanager.packages.to.scan.ws.microgrids}")
     private String entitymanagerPackagesToScan;
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
+    }
 
     @Override
     protected String getDatabaseUrl() {

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsSmartMeteringPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsSmartMeteringPersistenceConfig.java
@@ -29,9 +29,6 @@ public class AdapterWsSmartMeteringPersistenceConfig extends ApplicationPersiste
     @Value("${db.name.osgp_adapter_ws_smartmetering}")
     private String databaseName;
 
-    @Value("${osgpadapterwssmartmeteringdbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan}")
     private String entitymanagerPackagesToScan;
 
@@ -41,11 +38,6 @@ public class AdapterWsSmartMeteringPersistenceConfig extends ApplicationPersiste
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsSmartMeteringPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/AdapterWsSmartMeteringPersistenceConfig.java
@@ -26,6 +26,9 @@ import com.alliander.osgp.adapter.ws.smartmetering.domain.repositories.MeterResp
     basePackageClasses = { MeterResponseDataRepository.class })
 public class AdapterWsSmartMeteringPersistenceConfig extends ApplicationPersistenceConfiguration {
 
+    @Value("${db.name.osgp_adapter_ws_smartmetering}")
+    private String databaseName;
+
     @Value("${osgpadapterwssmartmeteringdbs.url}")
     private String databaseUrl;
 
@@ -33,6 +36,11 @@ public class AdapterWsSmartMeteringPersistenceConfig extends ApplicationPersiste
     private String entitymanagerPackagesToScan;
 
     public AdapterWsSmartMeteringPersistenceConfig() {
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/ApplicationPersistenceConfiguration.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/ApplicationPersistenceConfiguration.java
@@ -16,9 +16,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.SingleConnectionDataSource;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import com.alliander.osgp.shared.infra.db.DefaultConnectionPoolFactory;
+import com.zaxxer.hikari.HikariDataSource;
 
 /**
  * Base class for the application persistence configuration.
@@ -34,6 +36,9 @@ public abstract class ApplicationPersistenceConfiguration extends BaseApplicatio
     @Value("${db.driver}")
     protected String databaseDriver;
 
+    @Value("${db.protocol}")
+    protected String databaseProtocol;
+
     @Value("${db.username}")
     protected String databaseUsername;
 
@@ -44,7 +49,16 @@ public abstract class ApplicationPersistenceConfiguration extends BaseApplicatio
     protected String databaseHostname;
 
     @Value("${db.port}")
-    protected String databasePort;
+    protected int databasePort;
+
+    @Value("${db.min_pool_size}")
+    protected int databaseMinPoolSize;
+    @Value("${db.max_pool_size}")
+    protected int databaseMaxPoolSize;
+    @Value("${db.auto_commit}")
+    protected boolean databaseAutoCommit;
+    @Value("${db.idle_timeout}")
+    protected int databaseIdleTimeout;
 
     protected static final String PROPERTY_NAME_HIBERNATE_DIALECT = "hibernate.dialect";
     @Value("${hibernate.dialect}")
@@ -62,10 +76,12 @@ public abstract class ApplicationPersistenceConfiguration extends BaseApplicatio
     @Value("${hibernate.show_sql}")
     protected String hibernateShowSql;
 
+    protected abstract String getDatabaseName();
+
     protected abstract String getDatabaseUrl();
 
     protected abstract String getEntitymanagerPackagesToScan();
-    
+
     /**
      * Default constructor
      */
@@ -80,22 +96,19 @@ public abstract class ApplicationPersistenceConfiguration extends BaseApplicatio
      */
     protected DataSource makeDataSource() {
 
-        final SingleConnectionDataSource singleConnectionDataSource = new SingleConnectionDataSource();
-        singleConnectionDataSource.setAutoCommit(false);
-        final Properties properties = new Properties();
-        properties.setProperty("socketTimeout", "0");
-        properties.setProperty("tcpKeepAlive", "true");
+        final DefaultConnectionPoolFactory factory = new DefaultConnectionPoolFactory.Builder()
+                .withUsername(this.databaseUsername).withPassword(this.databasePassword)
+                .withDriverClassName(this.databaseDriver).withProtocol(this.databaseProtocol)
+                .withDatabaseHost(this.databaseHostname).withDatabasePort(this.databasePort)
+                .withDatabaseName(this.getDatabaseName()).withMinPoolSize(this.databaseMinPoolSize)
+                .withMaxPoolSize(this.databaseMaxPoolSize).withAutoCommit(this.databaseAutoCommit)
+                .withIdleTimeout(this.databaseIdleTimeout).build();
 
-        singleConnectionDataSource.setDriverClassName(this.databaseDriver);
-        singleConnectionDataSource.setUrl(this.getDatabaseUrl());
-        singleConnectionDataSource.setUsername(this.databaseUsername);
-        singleConnectionDataSource.setPassword(this.databasePassword);
-        singleConnectionDataSource.setSuppressClose(true);
+        final HikariDataSource hikariDataSource = factory.getDefaultConnectionPool();
 
-        LOGGER.info("Connecting to database {} as {}", singleConnectionDataSource.getUrl(),
-                singleConnectionDataSource.getUsername());
+        LOGGER.info("Connecting to database {} as {}", hikariDataSource.getJdbcUrl(), hikariDataSource.getUsername());
 
-        return singleConnectionDataSource;
+        return hikariDataSource;
     }
 
     /**

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/ApplicationPersistenceConfiguration.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/ApplicationPersistenceConfiguration.java
@@ -78,8 +78,6 @@ public abstract class ApplicationPersistenceConfiguration extends BaseApplicatio
 
     protected abstract String getDatabaseName();
 
-    protected abstract String getDatabaseUrl();
-
     protected abstract String getEntitymanagerPackagesToScan();
 
     /**

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/CorePersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/CorePersistenceConfig.java
@@ -27,6 +27,9 @@ import com.alliander.osgp.domain.microgrids.repositories.RtuDeviceRepository;
         DeviceRepository.class, RtuDeviceRepository.class })
 public class CorePersistenceConfig extends ApplicationPersistenceConfiguration {
 
+    @Value("${db.name.osgp_core}")
+    private String databaseName;
+
     @Value("${osgpcoredbs.url}")
     private String databaseUrl;
 
@@ -60,6 +63,11 @@ public class CorePersistenceConfig extends ApplicationPersistenceConfiguration {
             throws ClassNotFoundException {
 
         return this.makeEntityManager("OSGP_CUCUMBER_CORE", dataSource);
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/CorePersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/CorePersistenceConfig.java
@@ -30,9 +30,6 @@ public class CorePersistenceConfig extends ApplicationPersistenceConfiguration {
     @Value("${db.name.osgp_core}")
     private String databaseName;
 
-    @Value("${osgpcoredbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan.core}")
     private String entitymanagerPackagesToScan;
 
@@ -68,11 +65,6 @@ public class CorePersistenceConfig extends ApplicationPersistenceConfiguration {
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/LoggingPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/LoggingPersistenceConfig.java
@@ -25,6 +25,9 @@ import com.alliander.osgp.logging.domain.repositories.DeviceLogItemRepository;
 @EnableJpaRepositories(entityManagerFactoryRef = "entityMgrLogging", transactionManagerRef = "txMgrLogging", basePackageClasses = { DeviceLogItemRepository.class })
 public class LoggingPersistenceConfig extends ApplicationPersistenceConfiguration {
 
+    @Value("${db.name.osgp_logging}")
+    private String databaseName;
+
     @Value("${osgploggingdbs.url}")
     private String databaseUrl;
 
@@ -32,6 +35,11 @@ public class LoggingPersistenceConfig extends ApplicationPersistenceConfiguratio
     private String entitymanagerPackagesToScan;
 
     public LoggingPersistenceConfig() {
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return this.databaseName;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/LoggingPersistenceConfig.java
+++ b/cucumber-tests-platform/src/test/java/com/alliander/osgp/cucumber/platform/config/LoggingPersistenceConfig.java
@@ -28,9 +28,6 @@ public class LoggingPersistenceConfig extends ApplicationPersistenceConfiguratio
     @Value("${db.name.osgp_logging}")
     private String databaseName;
 
-    @Value("${osgploggingdbs.url}")
-    private String databaseUrl;
-
     @Value("${entitymanager.packages.to.scan.logging}")
     private String entitymanagerPackagesToScan;
 
@@ -40,11 +37,6 @@ public class LoggingPersistenceConfig extends ApplicationPersistenceConfiguratio
     @Override
     protected String getDatabaseName() {
         return this.databaseName;
-    }
-
-    @Override
-    protected String getDatabaseUrl() {
-        return this.databaseUrl;
     }
 
     @Override

--- a/cucumber-tests-platform/src/test/resources/cucumber-platform.properties
+++ b/cucumber-tests-platform/src/test/resources/cucumber-platform.properties
@@ -9,17 +9,30 @@ certificate.basepath=../certificates
 db.username=osp_admin
 db.password=1234
 db.driver=org.postgresql.Driver
+db.protocol=jdbc:postgresql://
 db.hostname=localhost
 db.port=5432
 
-osgpcoredbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_core
-osgploggingdbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_logging
-osgpadapterwssmartmeteringdbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_adapter_ws_smartmetering
-osgpadapterprotocoldlmsdbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_adapter_protocol_dlms
-osgpadapterprotocoloslpdbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_adapter_protocol_oslp
-osgpadapterwsmicrogridsdbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_adapter_ws_microgrids
-osgpadapterwsadmindbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_adapter_ws_admin
-osgpadapterprotocoliec61850dbs.url=jdbc:postgresql://${db.hostname}:${db.port}/osgp_adapter_protocol_iec61850
+db.min_pool_size=1
+db.max_pool_size=5
+db.auto_commit=false
+db.idle_timeout=120000
+
+db.name.osgp_core=osgp_core
+db.name.osgp_logging=osgp_logging
+db.name.osgp_adapter_ws_smartmetering=osgp_adapter_ws_smartmetering
+db.name.osgp_adapter_protocol_dlms=osgp_adapter_protocol_dlms
+db.name.osgp_adapter_protocol_oslp=osgp_adapter_protocol_oslp
+db.name.osgp_adapter_ws_microgrids=osgp_adapter_ws_microgrids
+db.name.osgp_adapter_protocol_iec61850=osgp_adapter_protocol_iec61850
+
+osgpcoredbs.url=${db.protocol}${db.hostname}:${db.port}/${db.name.osgp_core}
+osgploggingdbs.url=${db.protocol}${db.hostname}:${db.port}/${db.name.osgp_logging}
+osgpadapterwssmartmeteringdbs.url=${db.protocol}${db.hostname}:${db.port}/${db.name.osgp_adapter_ws_smartmetering}
+osgpadapterprotocoldlmsdbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_protocol_dlms}
+osgpadapterprotocoloslpdbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_protocol_oslp}
+osgpadapterwsmicrogridsdbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_ws_microgrids}
+osgpadapterprotocoliec61850dbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_protocol_iec61850}
 
 # Hibernate Configuration
 hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/cucumber-tests-platform/src/test/resources/cucumber-platform.properties
+++ b/cucumber-tests-platform/src/test/resources/cucumber-platform.properties
@@ -26,14 +26,6 @@ db.name.osgp_adapter_protocol_oslp=osgp_adapter_protocol_oslp
 db.name.osgp_adapter_ws_microgrids=osgp_adapter_ws_microgrids
 db.name.osgp_adapter_protocol_iec61850=osgp_adapter_protocol_iec61850
 
-osgpcoredbs.url=${db.protocol}${db.hostname}:${db.port}/${db.name.osgp_core}
-osgploggingdbs.url=${db.protocol}${db.hostname}:${db.port}/${db.name.osgp_logging}
-osgpadapterwssmartmeteringdbs.url=${db.protocol}${db.hostname}:${db.port}/${db.name.osgp_adapter_ws_smartmetering}
-osgpadapterprotocoldlmsdbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_protocol_dlms}
-osgpadapterprotocoloslpdbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_protocol_oslp}
-osgpadapterwsmicrogridsdbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_ws_microgrids}
-osgpadapterprotocoliec61850dbs.url=${db.protocol}${db.hostname}:${db.port}/{db.name.osgp_adapter_protocol_iec61850}
-
 # Hibernate Configuration
 hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 hibernate.format_sql=true


### PR DESCRIPTION
During testing of Bypass Retry, there were database connection
issues. Changing the SingleConnectionDataSource for the Cucumber
tests to the HikariDataSource is an attempt to get rid of these
errors like "PSQLException: This connection has been closed".