### PR TITLE
SLIM-975 loosens security on SimulatorTriggerClient for tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = development 
+	branch = SLIM-975-drops-truststore-from-simulator-client-test-config 
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/config/DlmsSimulatorConfig.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/config/DlmsSimulatorConfig.java
@@ -21,21 +21,12 @@ public class DlmsSimulatorConfig extends AbstractConfig {
     public DlmsSimulatorConfig() {
     }
 
-    @Value("${web.service.truststore.location}")
-    private String truststoreLocation;
-
-    @Value("${web.service.truststore.password}")
-    private String truststorePassword;
-
-    @Value("${web.service.truststore.type}")
-    private String truststoreType;
-
     @Value("${dynamic.properties.base.url}")
     private String dynamicPropertiesBaseUrl;
 
     @Bean
     public SimulatorTriggerClient simulatorTriggerClient() throws SimulatorTriggerClientException {
-        return new SimulatorTriggerClient(this.truststoreLocation, this.truststorePassword, this.truststoreType,
-                this.dynamicPropertiesBaseUrl);
+
+        return new SimulatorTriggerClient(this.dynamicPropertiesBaseUrl);
     }
 }


### PR DESCRIPTION
Update configuration of SimulatorTriggerClient for
the tests, only providing the base URI and dropping
the set up of a trust store.