### PR TITLE
Allow DA Cucumber scripts by adding org.osgpfoundation.osgp

### DIFF
--- a/cucumber-tests-core/src/test/java/com/alliander/osgp/cucumber/core/ApplicationContext.java
+++ b/cucumber-tests-core/src/test/java/com/alliander/osgp/cucumber/core/ApplicationContext.java
@@ -2,7 +2,7 @@ package com.alliander.osgp.cucumber.core;
 
 import org.springframework.context.annotation.ComponentScan;
 
-@ComponentScan(basePackages = { "com.alliander.osgp.cucumber" })
+@ComponentScan(basePackages = { "com.alliander.osgp.cucumber", "org.osgpfoundation.osgp.cucumber" })
 public class ApplicationContext {
 
 }


### PR DESCRIPTION
To allow DA Platform cucumber testing, we need to add org.osgpfoundation.osgp.cucumber packages tot the component scan.