### PR TITLE
SLIM-1475 Updates HLS 5 connection tests to verify IC increments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = SLIM-1475-Setup-HLS5-connection-with-invocation-counter
+	branch = development
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = development
+	branch = SLIM-1475-Setup-HLS5-connection-with-invocation-counter
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/PlatformSmartmeteringKeys.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/PlatformSmartmeteringKeys.java
@@ -80,6 +80,7 @@ public class PlatformSmartmeteringKeys extends com.alliander.osgp.cucumber.platf
     public static final String SECURITY_TYPE_A = "SecurityKeyTypeAuthentication";
     public static final String SECURITY_TYPE_E = "SecurityKeyTypeEncryption";
     public static final String SECURITY_TYPE_M = "SecurityKeyTypeMaster";
+    public static final String INVOCATION_COUNTER = "InvocationCounter";
     public static final String NETWORK_ADDRESS = "NetworkAddress";
     public static final String PORT = "Port";
     public static final Object PROTOCOL = "Protocol";

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/builders/entities/SecurityKeyBuilder.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/builders/entities/SecurityKeyBuilder.java
@@ -16,6 +16,7 @@ import org.osgp.adapter.protocol.dlms.domain.entities.SecurityKey;
 import org.osgp.adapter.protocol.dlms.domain.entities.SecurityKeyType;
 
 import com.alliander.osgp.cucumber.platform.core.builders.CucumberBuilder;
+import com.alliander.osgp.cucumber.platform.helpers.SettingsHelper;
 import com.alliander.osgp.cucumber.platform.helpers.UtcDateHelper;
 import com.alliander.osgp.cucumber.platform.inputparsers.DateInputParser;
 import com.alliander.osgp.cucumber.platform.smartmetering.PlatformSmartmeteringDefaults;
@@ -30,6 +31,7 @@ public class SecurityKeyBuilder implements CucumberBuilder<SecurityKey> {
     private Date validTo = PlatformSmartmeteringDefaults.VALID_TO;
     private Long version = PlatformSmartmeteringDefaults.VERSION;
     private String key = PlatformSmartmeteringDefaults.SECURITY_KEY_A_DB;
+    private Integer invocationCounter = null;
 
     private DlmsDevice dlmsDevice;
 
@@ -55,6 +57,11 @@ public class SecurityKeyBuilder implements CucumberBuilder<SecurityKey> {
 
     public SecurityKeyBuilder setKey(final String key) {
         this.key = key;
+        return this;
+    }
+
+    public SecurityKeyBuilder setInvocationCounter(final Integer invocationCounter) {
+        this.invocationCounter = invocationCounter;
         return this;
     }
 
@@ -105,6 +112,11 @@ public class SecurityKeyBuilder implements CucumberBuilder<SecurityKey> {
             this.setKey(inputSettings.get(PlatformSmartmeteringKeys.PASSWORD));
         }
 
+        if (SecurityKeyType.E_METER_ENCRYPTION == this.securityKeyType) {
+            this.setInvocationCounter(
+                    SettingsHelper.getIntegerValue(inputSettings, PlatformSmartmeteringKeys.INVOCATION_COUNTER));
+        }
+
         return this;
     }
 
@@ -114,8 +126,7 @@ public class SecurityKeyBuilder implements CucumberBuilder<SecurityKey> {
                 this.validTo);
 
         securityKey.setVersion(this.version);
-        securityKey.setValidFrom(this.validFrom);
-        securityKey.setValidTo(this.validTo);
+        securityKey.setInvocationCounter(this.invocationCounter);
 
         return securityKey;
     }

--- a/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ConnectionSecurity.feature
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ConnectionSecurity.feature
@@ -32,6 +32,21 @@ Feature: SmartMetering Connection security
       | DeviceIdentification | TEST1024000000001 |
     Then the actual meter reads result should be returned
       | DeviceIdentification | TEST1024000000001 |
+    And the invocation counter for the encryption key of "TEST1024000000001" should be greater than 0
+
+  Scenario: Invocation counter with HLS5 encryption should be incremented after communication
+    Given a dlms device
+      | DeviceIdentification | TEST1024000000001 |
+      | DeviceType           | SMART_METER_E     |
+      | Hls3active           | false             |
+      | Hls4active           | false             |
+      | Hls5active           | true              |
+      | InvocationCounter    |                83 |
+    When the get actual meter reads request is received
+      | DeviceIdentification | TEST1024000000001 |
+    Then the actual meter reads result should be returned
+      | DeviceIdentification | TEST1024000000001 |
+    And the invocation counter for the encryption key of "TEST1024000000001" should be greater than 83
 
   # Needs a DlmsDevice simulator with security.enabled=false on port 1025
   Scenario: Communicate unencrypted


### PR DESCRIPTION
When communicating with HLS 5, the invocation counter stored with the
E-meter encryption key should be incremented. While this should be done
with an amount of the number of times the key has been used to encrypt
data, the tests only verify for any increment.