### PR TITLE
SLIM-869 Create an integration test https notification service

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "Platform"]
 	path = Platform
 	url = https://github.com/OSGP/Platform.git
-	branch = SLIM-869-Create-smartmetering-test-notification-service
+	branch = development
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 [submodule "Platform"]
 	path = Platform
 	url = https://github.com/OSGP/Platform.git
-	branch = development
+	branch = SLIM-869-Create-smartmetering-test-notification-service
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git

--- a/cucumber-tests-core/src/test/java/com/alliander/osgp/cucumber/core/RetryableAssert.java
+++ b/cucumber-tests-core/src/test/java/com/alliander/osgp/cucumber/core/RetryableAssert.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.core;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class RetryableAssert {
+
+    private RetryableAssert() {
+        // Private constructor, utility class.
+    }
+
+    /**
+     * Runs the given {@code assertion}, rescheduling it with the given
+     * {@code delay} if an {@link AssertionError} occurs, for a maximum of
+     * {@code numberOfRetries} times.
+     */
+    public static void assertWithRetries(final Runnable assertion, final int numberOfRetries, final long delay,
+            final TimeUnit unit) {
+
+        try {
+            assertion.run();
+        } catch (final AssertionError e) {
+            if (numberOfRetries < 1) {
+                throw e;
+            }
+            assertDelayedWithRetries(assertion, numberOfRetries - 1, delay, unit);
+        }
+    }
+
+    /**
+     * Runs the given {@code assertion} after an initial {@code delay},
+     * rescheduling it with that same {@code delay} if an {@link AssertionError}
+     * occurs, for a maximum of {@code numberOfRetries} times.
+     */
+    public static void assertDelayedWithRetries(final Runnable assertion, final int numberOfRetries, final long delay,
+            final TimeUnit unit) {
+
+        try {
+            Executors.newSingleThreadScheduledExecutor()
+                    .schedule(() -> assertWithRetries(assertion, numberOfRetries, delay, unit), delay, unit).get();
+        } catch (final InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new CompletionException(ie);
+        } catch (final ExecutionException ee) {
+            if (ee.getCause() instanceof AssertionError) {
+                throw (AssertionError) ee.getCause();
+            } else {
+                throw new CompletionException(ee.getCause());
+            }
+        }
+    }
+}

--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/config/PlatformMicrogridsConfiguration.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/config/PlatformMicrogridsConfiguration.java
@@ -7,7 +7,6 @@
  */
 package com.alliander.osgp.cucumber.platform.microgrids.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
@@ -20,24 +19,4 @@ import com.alliander.osgp.cucumber.platform.config.AbstractPlatformApplicationCo
         @PropertySource(value = "file:/etc/osp/test/cucumber-tests-platform-microgrids.properties", ignoreResourceNotFound = true), })
 public class PlatformMicrogridsConfiguration extends AbstractPlatformApplicationConfiguration {
 
-    @Value("${jaxb2.marshaller.context.path.microgrids.notification}")
-    private String contextPathMicrogridsNotification;
-
-    @Value("${web.service.notification.context}")
-    private String notificationsContextPath;
-
-    @Value("${web.service.notification.port}")
-    private int notificationsPort;
-
-    public String getContextPathMicrogridsNotification() {
-        return this.contextPathMicrogridsNotification;
-    }
-
-    public String getNotificationsContextPath() {
-        return this.notificationsContextPath;
-    }
-
-    public int getNotificationsPort() {
-        return this.notificationsPort;
-    }
 }

--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/glue/steps/database/ws/ResponseDataSteps.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/glue/steps/database/ws/ResponseDataSteps.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertNull;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.alliander.osgp.adapter.ws.domain.entities.ResponseData;
 import com.alliander.osgp.adapter.ws.domain.repositories.ResponseDataRepository;
 import com.alliander.osgp.cucumber.core.DateTimeHelper;
+import com.alliander.osgp.cucumber.core.RetryableAssert;
 import com.alliander.osgp.cucumber.core.ScenarioContext;
 import com.alliander.osgp.cucumber.platform.PlatformKeys;
 import com.alliander.osgp.cucumber.platform.glue.steps.database.core.BaseDeviceSteps;
@@ -73,14 +75,8 @@ public class ResponseDataSteps extends BaseDeviceSteps {
                 .parseShort(settings.get(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT));
         final String expectedMessageType = settings.get(PlatformKeys.KEY_MESSAGE_TYPE);
 
-        try {
-            this.assertResponseDataHasNotificationsAndMessageType(correlationUid, expectedNumberOfNotificationsSent,
-                    expectedMessageType);
-        } catch (final AssertionError e) {
-            Thread.sleep(500);
-            this.assertResponseDataHasNotificationsAndMessageType(correlationUid, expectedNumberOfNotificationsSent,
-                    expectedMessageType);
-        }
+        RetryableAssert.assertWithRetries(() -> ResponseDataSteps.this.assertResponseDataHasNotificationsAndMessageType(
+                correlationUid, expectedNumberOfNotificationsSent, expectedMessageType), 3, 200, TimeUnit.MILLISECONDS);
     }
 
     private void assertResponseDataHasNotificationsAndMessageType(final String correlationUid,

--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/glue/steps/database/ws/ResponseDataSteps.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/glue/steps/database/ws/ResponseDataSteps.java
@@ -69,12 +69,27 @@ public class ResponseDataSteps extends BaseDeviceSteps {
     @Then("^the response data has values$")
     public void theResponseDataHasValues(final Map<String, String> settings) throws Throwable {
         final String correlationUid = settings.get(PlatformKeys.KEY_CORRELATION_UID);
+        final short expectedNumberOfNotificationsSent = Short
+                .parseShort(settings.get(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT));
+        final String expectedMessageType = settings.get(PlatformKeys.KEY_MESSAGE_TYPE);
+
+        try {
+            this.assertResponseDataHasNotificationsAndMessageType(correlationUid, expectedNumberOfNotificationsSent,
+                    expectedMessageType);
+        } catch (final AssertionError e) {
+            Thread.sleep(500);
+            this.assertResponseDataHasNotificationsAndMessageType(correlationUid, expectedNumberOfNotificationsSent,
+                    expectedMessageType);
+        }
+    }
+
+    private void assertResponseDataHasNotificationsAndMessageType(final String correlationUid,
+            final Short expectedNumberOfNotificationsSent, final String expectedMessageType) {
+
         final ResponseData responseData = this.responseDataRespository.findByCorrelationUid(correlationUid);
 
-        assertEquals(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT,
-                settings.get(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT),
-                responseData.getNumberOfNotificationsSent().toString());
-        assertEquals(PlatformKeys.KEY_MESSAGE_TYPE, settings.get(PlatformKeys.KEY_MESSAGE_TYPE),
-                responseData.getMessageType());
+        assertEquals(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT, expectedNumberOfNotificationsSent,
+                responseData.getNumberOfNotificationsSent());
+        assertEquals(PlatformKeys.KEY_MESSAGE_TYPE, expectedMessageType, responseData.getMessageType());
     }
 }

--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/support/ws/microgrids/NotificationService.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/support/ws/microgrids/NotificationService.java
@@ -7,7 +7,13 @@
  */
 package com.alliander.osgp.cucumber.platform.microgrids.support.ws.microgrids;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,10 +26,11 @@ public class NotificationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NotificationService.class);
 
-    private ConcurrentLinkedQueue<Notification> queue = new ConcurrentLinkedQueue<>();
+    private BlockingQueue<Notification> queue = new LinkedBlockingQueue<>();
 
     public void handleNotification(final Notification notification, final String organisationIdentification) {
-        LOGGER.info("Notification received: {}", notification.getCorrelationUid());
+        LOGGER.info("Notification received: {} for type {} with result {}", notification.getCorrelationUid(),
+                notification.getNotificationType(), notification.getResult());
         this.queue.add(notification);
     }
 
@@ -37,5 +44,47 @@ public class NotificationService {
 
     public void clearAllNotifications() {
         this.queue.clear();
+    }
+
+    public Notification getNotification(final long timeout, final TimeUnit unit) {
+        try {
+            return this.queue.poll(timeout, unit);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.trace("getNotification was interrupted", e);
+        }
+        return null;
+    }
+
+    public Notification getNotification(final String correlationUid, final long timeout, final TimeUnit unit) {
+        final long maxTimeout = unit.toMillis(timeout);
+        try {
+            return CompletableFuture.supplyAsync(() -> {
+                final long startTime = System.currentTimeMillis();
+                long remaining = maxTimeout;
+                while (remaining > 0) {
+                    try {
+                        final Notification notification = this.queue.poll(remaining, TimeUnit.MILLISECONDS);
+                        if (notification != null && correlationUid.equals(notification.getCorrelationUid())) {
+                            return notification;
+                        }
+                        final long elapsed = System.currentTimeMillis() - startTime;
+                        remaining = maxTimeout - elapsed;
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new CompletionException(e);
+                    }
+                }
+                return null;
+            }).get(maxTimeout, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.trace("getNotification for correlation UID {} was interrupted", correlationUid, e);
+        } catch (final ExecutionException e) {
+            LOGGER.error("An exception occurred getting a notification for correlation UID {}", correlationUid, e);
+        } catch (final TimeoutException e) {
+            LOGGER.trace("getNotification for correlation UID {} timed out", correlationUid, e);
+        }
+        return null;
     }
 }

--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/support/ws/microgrids/adhocmanagement/AdHocManagementClient.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/support/ws/microgrids/adhocmanagement/AdHocManagementClient.java
@@ -83,10 +83,10 @@ public class AdHocManagementClient extends BaseClient {
     private void waitForResponseData(final String correlationUid) {
         try {
             for (int timeSpentWaiting = 0; timeSpentWaiting < this.waitFailMillis; timeSpentWaiting += this.waitCheckIntervalMillis) {
-                Thread.sleep(this.waitCheckIntervalMillis);
                 if (this.responseDataRepository.findByCorrelationUid(correlationUid) != null) {
                     return;
                 }
+                Thread.sleep(this.waitCheckIntervalMillis);
             }
             throw new AssertionError("RtuResponseData not available within " + this.waitFailMillis + " milliseconds.");
         } catch (final InterruptedException e) {

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/config/ws/smartmetering/SmartMeteringNotificationWebServiceConfig.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/config/ws/smartmetering/SmartMeteringNotificationWebServiceConfig.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.config.ws.smartmetering;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.springframework.remoting.support.SimpleHttpServerFactoryBean;
+import org.springframework.ws.config.annotation.EnableWs;
+import org.springframework.ws.config.annotation.WsConfigurerAdapter;
+import org.springframework.ws.server.EndpointInterceptor;
+import org.springframework.ws.server.endpoint.adapter.DefaultMethodEndpointAdapter;
+import org.springframework.ws.server.endpoint.adapter.method.MarshallingPayloadMethodProcessor;
+import org.springframework.ws.server.endpoint.adapter.method.MethodArgumentResolver;
+import org.springframework.ws.server.endpoint.adapter.method.MethodReturnValueHandler;
+import org.springframework.ws.server.endpoint.mapping.PayloadRootAnnotationMethodEndpointMapping;
+import org.springframework.ws.soap.saaj.SaajSoapMessageFactory;
+import org.springframework.ws.soap.server.SoapMessageDispatcher;
+import org.springframework.ws.transport.http.WebServiceMessageReceiverHttpHandler;
+
+import com.alliander.osgp.adapter.ws.endpointinterceptors.AnnotationMethodArgumentResolver;
+import com.alliander.osgp.adapter.ws.endpointinterceptors.OrganisationIdentification;
+import com.alliander.osgp.adapter.ws.endpointinterceptors.SoapHeaderEndpointInterceptor;
+
+@EnableWs
+@Configuration
+public class SmartMeteringNotificationWebServiceConfig extends WsConfigurerAdapter {
+
+    private static final String ORGANISATION_IDENTIFICATION_HEADER = "OrganisationIdentification";
+
+    @Value("${jaxb2.marshaller.context.path.smartmetering.notification}")
+    private String contextPathSmartMeteringNotification;
+
+    @Value("${web.service.notification.context}")
+    private String notificationContextPath;
+
+    @Value("${web.service.notification.port}")
+    private int notificationPort;
+
+    @Bean
+    public DefaultMethodEndpointAdapter defaultMethodEndpointAdapter() {
+        final DefaultMethodEndpointAdapter defaultMethodEndpointAdapter = new DefaultMethodEndpointAdapter();
+
+        final List<MethodArgumentResolver> methodArgumentResolvers = new ArrayList<>();
+        methodArgumentResolvers.add(this.smartMeteringNotificationMarshallingPayloadMethodProcessor());
+        methodArgumentResolvers.add(new AnnotationMethodArgumentResolver(ORGANISATION_IDENTIFICATION_HEADER,
+                OrganisationIdentification.class));
+        defaultMethodEndpointAdapter.setMethodArgumentResolvers(methodArgumentResolvers);
+
+        final List<MethodReturnValueHandler> methodReturnValueHandlers = new ArrayList<>();
+        methodReturnValueHandlers.add(this.smartMeteringNotificationMarshallingPayloadMethodProcessor());
+        defaultMethodEndpointAdapter.setMethodReturnValueHandlers(methodReturnValueHandlers);
+
+        return defaultMethodEndpointAdapter;
+    }
+
+    @Override
+    public void addInterceptors(final List<EndpointInterceptor> interceptors) {
+        interceptors.add(new SoapHeaderEndpointInterceptor(ORGANISATION_IDENTIFICATION_HEADER,
+                ORGANISATION_IDENTIFICATION_HEADER));
+    }
+
+    @Bean
+    public SimpleHttpServerFactoryBean httpServer(final SaajSoapMessageFactory messageFactory,
+            final DefaultMethodEndpointAdapter defaultMethodEndpointAdapter,
+            final PayloadRootAnnotationMethodEndpointMapping mapping) {
+
+        final SoapMessageDispatcher soapMessageDispatcher = new SoapMessageDispatcher();
+        soapMessageDispatcher.setEndpointMappings(Arrays.asList(mapping));
+        soapMessageDispatcher.setEndpointAdapters(Arrays.asList(defaultMethodEndpointAdapter));
+
+        final WebServiceMessageReceiverHttpHandler httpHandler = new WebServiceMessageReceiverHttpHandler();
+        httpHandler.setMessageReceiver(soapMessageDispatcher);
+        httpHandler.setMessageFactory(messageFactory);
+
+        final SimpleHttpServerFactoryBean httpServer = new SimpleHttpServerFactoryBean();
+        httpServer.setContexts(Collections.singletonMap(this.notificationContextPath, httpHandler));
+        httpServer.setPort(this.notificationPort);
+
+        return httpServer;
+    }
+
+    @Bean
+    public Jaxb2Marshaller smartMeteringNotificationMarshaller() {
+        final Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
+        marshaller.setContextPath(this.contextPathSmartMeteringNotification);
+        return marshaller;
+    }
+
+    @Bean
+    public MarshallingPayloadMethodProcessor smartMeteringNotificationMarshallingPayloadMethodProcessor() {
+        return new MarshallingPayloadMethodProcessor(this.smartMeteringNotificationMarshaller(),
+                this.smartMeteringNotificationMarshaller());
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/database/ws/ResponseDataSteps.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/database/ws/ResponseDataSteps.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertNull;
 
 import java.lang.reflect.Field;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.alliander.osgp.adapter.ws.domain.entities.ResponseData;
 import com.alliander.osgp.adapter.ws.domain.repositories.ResponseDataRepository;
 import com.alliander.osgp.cucumber.core.DateTimeHelper;
+import com.alliander.osgp.cucumber.core.RetryableAssert;
 import com.alliander.osgp.cucumber.core.ScenarioContext;
 import com.alliander.osgp.cucumber.platform.PlatformKeys;
 import com.alliander.osgp.cucumber.platform.glue.steps.database.core.BaseDeviceSteps;
@@ -74,14 +76,8 @@ public class ResponseDataSteps extends BaseDeviceSteps {
                 .parseShort(settings.get(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT));
         final String expectedMessageType = settings.get(PlatformKeys.KEY_MESSAGE_TYPE);
 
-        try {
-            this.assertResponseDataHasNotificationsAndMessageType(correlationUid, expectedNumberOfNotificationsSent,
-                    expectedMessageType);
-        } catch (final AssertionError e) {
-            Thread.sleep(500);
-            this.assertResponseDataHasNotificationsAndMessageType(correlationUid, expectedNumberOfNotificationsSent,
-                    expectedMessageType);
-        }
+        RetryableAssert.assertWithRetries(() -> ResponseDataSteps.this.assertResponseDataHasNotificationsAndMessageType(
+                correlationUid, expectedNumberOfNotificationsSent, expectedMessageType), 3, 200, TimeUnit.MILLISECONDS);
     }
 
     private void assertResponseDataHasNotificationsAndMessageType(final String correlationUid,

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/notification/NotificationSteps.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/notification/NotificationSteps.java
@@ -10,15 +10,19 @@ package com.alliander.osgp.cucumber.platform.smartmetering.glue.steps.ws.smartme
 
 import static org.junit.Assert.fail;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.alliander.osgp.adapter.ws.domain.entities.ResponseData;
-import com.alliander.osgp.adapter.ws.domain.repositories.ResponseDataRepository;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.notification.Notification;
 import com.alliander.osgp.cucumber.core.ScenarioContext;
 import com.alliander.osgp.cucumber.platform.PlatformKeys;
 import com.alliander.osgp.cucumber.platform.smartmetering.glue.steps.ws.smartmetering.notifications.ResendNotificationJobSteps;
+import com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.notification.NotificationService;
 
 import cucumber.api.java.en.Then;
 
@@ -26,7 +30,6 @@ public class NotificationSteps {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResendNotificationJobSteps.class);
 
-    private static final int WAIT_FOR_NEXT_NOTIFICATION_CHECK = 1000;
     /*
      * Allow a little more time than the period for the job trigger to re-send
      * notifications.
@@ -34,77 +37,61 @@ public class NotificationSteps {
     private static final int MAX_WAIT_FOR_NOTIFICATION = 65000;
 
     @Autowired
-    private ResponseDataRepository responseDataRespository;
+    private NotificationService notificationService;
 
     @Then("^a notification is sent$")
     public void aNotificationIsSent() throws Throwable {
 
-        /*
-         * Preferably the actual notification would be caught in the code
-         * backing the test scenarios, but such a mechanism is not yet in place
-         * for smart metering.
-         *
-         * As a workaround the correlation UID and number of notifications sent
-         * for response data is stored in the scenario context when the given
-         * response data is setup.
-         *
-         * If the actual response data has a higher number of notifications sent
-         * than the value stored in the scenario context, assume a notification
-         * has been sent.
-         */
-
         final String correlationUid = (String) ScenarioContext.current().get(PlatformKeys.KEY_CORRELATION_UID);
-        final Short numberOfNotificationsSent = (Short) ScenarioContext.current()
-                .get(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT);
-        if (correlationUid == null || numberOfNotificationsSent == null) {
-            fail("No " + PlatformKeys.KEY_CORRELATION_UID + " or " + PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT
+        if (correlationUid == null) {
+            fail("No " + PlatformKeys.KEY_CORRELATION_UID
                     + " stored in the scenario context. Unable to make assumptions as to whether a notification has been sent.");
         }
 
-        for (int delayedtime = 0; delayedtime < MAX_WAIT_FOR_NOTIFICATION; delayedtime += WAIT_FOR_NEXT_NOTIFICATION_CHECK) {
-            try {
-                Thread.sleep(WAIT_FOR_NEXT_NOTIFICATION_CHECK);
-            } catch (final InterruptedException e) {
-                LOGGER.error("Thread sleep interrupted ", e.getMessage());
-                break;
-            }
-            final ResponseData responseData = this.responseDataRespository.findByCorrelationUid(correlationUid);
-            if (responseData.getNumberOfNotificationsSent() > numberOfNotificationsSent) {
-                return;
-            }
+        try {
+            this.notificationService.getNotification(correlationUid).get(MAX_WAIT_FOR_NOTIFICATION,
+                    TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(
+                    "Thread was interrupted while awaiting notification for correlation UID: " + correlationUid, e);
+        } catch (final ExecutionException e) {
+            throw new AssertionError("Exception while obtaining notification for correlation UID: " + correlationUid,
+                    e);
+        } catch (final TimeoutException e) {
+            fail("A notification for correlation UID " + correlationUid + " has not been sent within "
+                    + MAX_WAIT_FOR_NOTIFICATION + " milliseconds.");
         }
-
-        fail("A notification for correlation UID " + correlationUid + " has not been sent within "
-                + MAX_WAIT_FOR_NOTIFICATION + " milliseconds");
     }
 
     @Then("^no notification is sent$")
     public void noNotificationIsSent() throws Throwable {
 
-        /*
-         * A workaround for the actual notification is in place, see the
-         * comments with aNotificationIsSent for more details.
-         */
-
         final String correlationUid = (String) ScenarioContext.current().get(PlatformKeys.KEY_CORRELATION_UID);
-        final Short numberOfNotificationsSent = (Short) ScenarioContext.current()
-                .get(PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT);
-        if (correlationUid == null || numberOfNotificationsSent == null) {
-            fail("No " + PlatformKeys.KEY_CORRELATION_UID + " or " + PlatformKeys.KEY_NUMBER_OF_NOTIFICATIONS_SENT
+        if (correlationUid == null) {
+            fail("No " + PlatformKeys.KEY_CORRELATION_UID
                     + " stored in the scenario context. Unable to make assumptions as to whether a notification has been sent.");
         }
 
-        for (int delayedtime = 0; delayedtime < MAX_WAIT_FOR_NOTIFICATION; delayedtime += WAIT_FOR_NEXT_NOTIFICATION_CHECK) {
-            try {
-                Thread.sleep(WAIT_FOR_NEXT_NOTIFICATION_CHECK);
-            } catch (final InterruptedException e) {
-                LOGGER.error("Thread sleep interrupted ", e.getMessage());
-                break;
-            }
-            final ResponseData responseData = this.responseDataRespository.findByCorrelationUid(correlationUid);
-            if (responseData.getNumberOfNotificationsSent() > numberOfNotificationsSent) {
-                fail("A notification for correlation UID " + correlationUid + " was sent");
-            }
+        try {
+            final Notification notification = this.notificationService.getNotification(correlationUid)
+                    .get(MAX_WAIT_FOR_NOTIFICATION, TimeUnit.MILLISECONDS);
+            fail("A notification for correlation UID " + correlationUid + " for notification type "
+                    + notification.getNotificationType() + " was sent.");
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(
+                    "Thread was interrupted while awaiting no notification to be sent for correlation UID: "
+                            + correlationUid,
+                    e);
+        } catch (final ExecutionException e) {
+            throw new AssertionError(
+                    "Exception while obtaining the notification not to be sent for correlation UID: " + correlationUid,
+                    e);
+        } catch (final TimeoutException e) {
+            LOGGER.debug(
+                    "Got expected time-out waiting for notification that should not be sent for correlation UID: {} -> {}",
+                    correlationUid, e);
         }
     }
 }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/endpoints/SmartMeteringNotificationEndpoint.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/endpoints/SmartMeteringNotificationEndpoint.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.endpoints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.ws.server.endpoint.annotation.Endpoint;
+import org.springframework.ws.server.endpoint.annotation.PayloadRoot;
+import org.springframework.ws.server.endpoint.annotation.RequestPayload;
+import org.springframework.ws.server.endpoint.annotation.ResponsePayload;
+
+import com.alliander.osgp.adapter.ws.endpointinterceptors.OrganisationIdentification;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.notification.SendNotificationRequest;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.notification.SendNotificationResponse;
+import com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.notification.NotificationService;
+import com.alliander.osgp.shared.exceptionhandling.WebServiceException;
+
+@Endpoint
+public class SmartMeteringNotificationEndpoint {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SmartMeteringNotificationEndpoint.class);
+    private static final String SMARTMETERING_NOTIFICATION_NAMESPACE = "http://www.alliander.com/schemas/osgp/smartmetering/sm-notification/2014/10";
+
+    @Autowired
+    private NotificationService notificationService;
+
+    public SmartMeteringNotificationEndpoint() {
+        // Default constructor
+    }
+
+    @PayloadRoot(localPart = "SendNotificationRequest", namespace = SMARTMETERING_NOTIFICATION_NAMESPACE)
+    @ResponsePayload
+    public SendNotificationResponse sendNotification(
+            @OrganisationIdentification final String organisationIdentification,
+            @RequestPayload final SendNotificationRequest request) throws WebServiceException {
+
+        LOGGER.info("Incoming SendNotificationRequest for organisation: {} device: {}.", organisationIdentification,
+                request.getNotification().getDeviceIdentification());
+
+        this.notificationService.handleNotification(request.getNotification(), organisationIdentification);
+
+        return new SendNotificationResponse();
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/adhoc/SmartMeteringAdHocResponseClient.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/adhoc/SmartMeteringAdHocResponseClient.java
@@ -32,7 +32,7 @@ public class SmartMeteringAdHocResponseClient<T, V extends AsyncRequest> extends
 
     public T getResponse(final V request) throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
-        this.waitForDlmsResponseData(request.getCorrelationUid());
+        this.waitForNotification(request.getCorrelationUid());
         return (T) this.getTemplate().marshalSendAndReceive(request);
     }
 

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/bundle/SmartMeteringBundleClient.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/bundle/SmartMeteringBundleClient.java
@@ -37,7 +37,7 @@ public class SmartMeteringBundleClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = asyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (BundleResponse) this.getTemplate().marshalSendAndReceive(asyncRequest);
     }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SmartMeteringConfigurationClient.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SmartMeteringConfigurationClient.java
@@ -98,7 +98,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = updateFirmwareAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (UpdateFirmwareResponse) this.getTemplate().marshalSendAndReceive(updateFirmwareAsyncRequest);
     }
@@ -113,7 +113,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = getFirmwareVersionAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (GetFirmwareVersionResponse) this.getTemplate().marshalSendAndReceive(getFirmwareVersionAsyncRequest);
     }
@@ -129,7 +129,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setActivityCalendarAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetActivityCalendarResponse) this.getTemplate().marshalSendAndReceive(setActivityCalendarAsyncRequest);
     }
@@ -146,7 +146,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = getAdministrativeStatusAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (GetAdministrativeStatusResponse) this.getTemplate()
                 .marshalSendAndReceive(getAdministrativeStatusAsyncRequest);
@@ -164,7 +164,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setAdministrativeStatusAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetAdministrativeStatusResponse) this.getTemplate()
                 .marshalSendAndReceive(setAdministrativeStatusAsyncRequest);
@@ -182,7 +182,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setAlarmNotificationsAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetAlarmNotificationsResponse) this.getTemplate()
                 .marshalSendAndReceive(setAlarmNotificationsAsyncRequest);
@@ -200,7 +200,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setConfigurationObjectAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetConfigurationObjectResponse) this.getTemplate()
                 .marshalSendAndReceive(setConfigurationObjectAsyncRequest);
@@ -216,7 +216,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setSpecialDaysAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetSpecialDaysResponse) this.getTemplate().marshalSendAndReceive(setSpecialDaysAsyncRequest);
     }
@@ -233,7 +233,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setEncryptionKeyExchangeOnGMeterAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetEncryptionKeyExchangeOnGMeterResponse) this.getTemplate()
                 .marshalSendAndReceive(setEncryptionKeyExchangeOnGMeterAsyncRequest);
@@ -251,7 +251,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = getMbusEncryptionKeyStatusAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (GetMbusEncryptionKeyStatusResponse) this.getTemplate()
                 .marshalSendAndReceive(getMbusEncryptionKeyStatusAsyncRequest);
@@ -269,7 +269,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setMbusUserKeyByChannelAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetMbusUserKeyByChannelResponse) this.getTemplate()
                 .marshalSendAndReceive(setMbusUserKeyByChannelAsyncRequest);
@@ -285,7 +285,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = replaceKeysAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (ReplaceKeysResponse) this.getTemplate().marshalSendAndReceive(replaceKeysAsyncRequest);
     }
@@ -303,7 +303,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = generateAndReplaceKeysAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (GenerateAndReplaceKeysResponse) this.getTemplate()
                 .marshalSendAndReceive(generateAndReplaceKeysAsyncRequest);
@@ -321,7 +321,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = setClockConfigurationAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetClockConfigurationResponse) this.getTemplate()
                 .marshalSendAndReceive(setClockConfigurationAsyncRequest);
@@ -339,7 +339,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = configureDefinableLoadProfileAsyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (ConfigureDefinableLoadProfileResponse) this.getTemplate()
                 .marshalSendAndReceive(configureDefinableLoadProfileAsyncRequest);
@@ -354,7 +354,7 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
         final String correlationUid = asyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         return (SetPushSetupSmsResponse) this.getTemplate().marshalSendAndReceive(asyncRequest);
     }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/installation/SmartMeteringInstallationClient.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/installation/SmartMeteringInstallationClient.java
@@ -47,7 +47,7 @@ public class SmartMeteringInstallationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException {
 
         final String correlationUid = asyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         final WebServiceTemplate webServiceTemplate = this.smartMeteringInstallationWebServiceTemplateFactory
                 .getTemplate(this.getOrganizationIdentification(), this.getUserName());
@@ -65,7 +65,7 @@ public class SmartMeteringInstallationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException {
 
         final String correlationUid = asyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         final WebServiceTemplate webServiceTemplate = this.smartMeteringInstallationWebServiceTemplateFactory
                 .getTemplate(this.getOrganizationIdentification(), this.getUserName());
@@ -83,7 +83,7 @@ public class SmartMeteringInstallationClient extends SmartMeteringBaseClient {
             throws WebServiceSecurityException {
 
         final String correlationUid = asyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         final WebServiceTemplate webServiceTemplate = this.smartMeteringInstallationWebServiceTemplateFactory
                 .getTemplate(this.getOrganizationIdentification(), this.getUserName());
@@ -101,7 +101,7 @@ public class SmartMeteringInstallationClient extends SmartMeteringBaseClient {
             final CoupleMbusDeviceByChannelAsyncRequest asyncRequest) throws WebServiceSecurityException {
 
         final String correlationUid = asyncRequest.getCorrelationUid();
-        this.waitForDlmsResponseData(correlationUid);
+        this.waitForNotification(correlationUid);
 
         final WebServiceTemplate webServiceTemplate = this.smartMeteringInstallationWebServiceTemplateFactory
                 .getTemplate(this.getOrganizationIdentification(), this.getUserName());

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/management/SmartMeteringManagementResponseClient.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/management/SmartMeteringManagementResponseClient.java
@@ -32,7 +32,7 @@ public class SmartMeteringManagementResponseClient<T, V extends AsyncRequest> ex
 
     public T getResponse(final V request) throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
-        this.waitForDlmsResponseData(request.getCorrelationUid());
+        this.waitForNotification(request.getCorrelationUid());
         return (T) this.getTemplate().marshalSendAndReceive(request);
     }
 }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/monitoring/SmartMeteringMonitoringResponseClient.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/monitoring/SmartMeteringMonitoringResponseClient.java
@@ -32,7 +32,7 @@ public class SmartMeteringMonitoringResponseClient<T, V extends AsyncRequest> ex
 
     public T getResponse(final V request) throws WebServiceSecurityException, GeneralSecurityException, IOException {
 
-        this.waitForDlmsResponseData(request.getCorrelationUid());
+        this.waitForNotification(request.getCorrelationUid());
         return (T) this.getTemplate().marshalSendAndReceive(request);
     }
 

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/notification/NotificationService.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/notification/NotificationService.java
@@ -10,7 +10,10 @@ package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmeter
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,19 +46,45 @@ public class NotificationService {
         this.queue.clear();
     }
 
-    public CompletableFuture<Notification> getNotification(final String correlationUid) {
-        return CompletableFuture.supplyAsync(() -> {
-            while (true) {
-                try {
-                    final Notification notification = this.queue.take();
-                    if (correlationUid.equals(notification.getCorrelationUid())) {
-                        return notification;
+    public Notification getNotification(final long timeout, final TimeUnit unit) {
+        try {
+            return this.queue.poll(timeout, unit);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.trace("getNotification was interrupted", e);
+        }
+        return null;
+    }
+
+    public Notification getNotification(final String correlationUid, final long timeout, final TimeUnit unit) {
+        final long maxTimeout = unit.toMillis(timeout);
+        try {
+            return CompletableFuture.supplyAsync(() -> {
+                final long startTime = System.currentTimeMillis();
+                long remaining = maxTimeout;
+                while (remaining > 0) {
+                    try {
+                        final Notification notification = this.queue.poll(remaining, TimeUnit.MILLISECONDS);
+                        if (notification != null && correlationUid.equals(notification.getCorrelationUid())) {
+                            return notification;
+                        }
+                        final long elapsed = System.currentTimeMillis() - startTime;
+                        remaining = maxTimeout - elapsed;
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new CompletionException(e);
                     }
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new CompletionException(e);
                 }
-            }
-        });
+                return null;
+            }).get(maxTimeout, TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.trace("getNotification for correlation UID {} was interrupted", correlationUid, e);
+        } catch (final ExecutionException e) {
+            LOGGER.error("An exception occurred getting a notification for correlation UID {}", correlationUid, e);
+        } catch (final TimeoutException e) {
+            LOGGER.trace("getNotification for correlation UID {} timed out", correlationUid, e);
+        }
+        return null;
     }
 }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/notification/NotificationService.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/notification/NotificationService.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.notification;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.alliander.osgp.adapter.ws.schema.smartmetering.notification.Notification;
+
+@Component
+public class NotificationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NotificationService.class);
+
+    private BlockingQueue<Notification> queue = new LinkedBlockingQueue<>();
+
+    public void handleNotification(final Notification notification, final String organisationIdentification) {
+        LOGGER.info("Notification received: {} for type {} with result {}", notification.getCorrelationUid(),
+                notification.getNotificationType(), notification.getResult());
+        this.queue.add(notification);
+    }
+
+    public boolean receivedNotification() {
+        return !this.queue.isEmpty();
+    }
+
+    public Notification getNotification() {
+        return this.queue.poll();
+    }
+
+    public void clearAllNotifications() {
+        this.queue.clear();
+    }
+
+    public CompletableFuture<Notification> getNotification(final String correlationUid) {
+        return CompletableFuture.supplyAsync(() -> {
+            while (true) {
+                try {
+                    final Notification notification = this.queue.take();
+                    if (correlationUid.equals(notification.getCorrelationUid())) {
+                        return notification;
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new CompletionException(e);
+                }
+            }
+        });
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/resources/cucumber-tests-platform-smartmetering.properties
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/cucumber-tests-platform-smartmetering.properties
@@ -37,3 +37,8 @@ jaxb2.marshaller.context.path.smartmetering.management=com.alliander.osgp.adapte
 
 web.service.template.default.uri.smartmetering.monitoring=osgp-adapter-ws-smartmetering/smartmetering/monitoringService/
 jaxb2.marshaller.context.path.smartmetering.monitoring=com.alliander.osgp.adapter.ws.schema.smartmetering.monitoring
+
+jaxb2.marshaller.context.path.smartmetering.notification=com.alliander.osgp.adapter.ws.schema.smartmetering.notification
+
+web.service.notification.context=/notifications
+web.service.notification.port=8843


### PR DESCRIPTION
Adds a notification service to the Smart Metering tests, so that the
tests can respond to the actual notification instead of polling the
response data table to see if a response is available.

* Adds notification service properties to Cucumber configuration file.
* Adds a SmartMeterNotificationEndpoint to the test code with a custom
  NotificationService to be able to respond to actual notifications from
  OSGP.
* Replaces waiting based on response data and number of notifications
  sent by waiting for a notification to be received by the test
  notification end-point.