### PR TITLE
SLIM-1626 Make GprsOperationMode and ConfigurationFlags optional for SetConfigurationObject SLIM-1060

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060
 [submodule "Protocol-Adapter-OSLP"]
 	path = Protocol-Adapter-OSLP
 	url = https://github.com/OSGP/Protocol-Adapter-OSLP.git
@@ -9,11 +9,11 @@
 [submodule "Platform"]
 	path = Platform
 	url = https://github.com/OSGP/Platform.git
-	branch = development
+	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = development 
+	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060 
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060
+	branch = development
 [submodule "Protocol-Adapter-OSLP"]
 	path = Protocol-Adapter-OSLP
 	url = https://github.com/OSGP/Protocol-Adapter-OSLP.git
@@ -9,11 +9,11 @@
 [submodule "Platform"]
 	path = Platform
 	url = https://github.com/OSGP/Platform.git
-	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060
+	branch = development
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = SLIM-1626-Make-GprsOperationMode-ConfigurationFlagType-optional-for-SetConfigurationObject-SLIM-1060 
+	branch = development 
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/bundle/SetConfigurationObjectRequestBuilder.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/bundle/SetConfigurationObjectRequestBuilder.java
@@ -7,13 +7,11 @@
  */
 package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.bundle;
 
-import static com.alliander.osgp.cucumber.core.ReadSettingsHelper.getBoolean;
-import static com.alliander.osgp.cucumber.core.ReadSettingsHelper.getEnum;
-import static com.alliander.osgp.cucumber.core.ReadSettingsHelper.getInteger;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.springframework.util.CollectionUtils;
 
 import com.alliander.osgp.adapter.ws.schema.smartmetering.bundle.SetConfigurationObjectRequest;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlag;
@@ -21,13 +19,11 @@ import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.Configur
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlags;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationObject;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.GprsOperationModeType;
-import com.alliander.osgp.cucumber.platform.helpers.SettingsHelper;
-import com.alliander.osgp.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
+import com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.ConfigurationObjectFactory;
 
 public class SetConfigurationObjectRequestBuilder {
 
     private static final GprsOperationModeType DEFAULT_GPRS_OPERATION_MODE_TYPE = GprsOperationModeType.ALWAYS_ON;
-    private static final int DEFAULT_CONFIGURATION_FLAG_COUNT = 1;
     private static final ConfigurationFlagType DEFAULT_CONFIGURATION_FLAG_TYPE = ConfigurationFlagType.DISCOVER_ON_POWER_ON;
     private static final boolean DEFAULT_CONFIGURATION_FLAG_ENABLED = true;
 
@@ -42,34 +38,25 @@ public class SetConfigurationObjectRequestBuilder {
     }
 
     public SetConfigurationObjectRequestBuilder fromParameterMap(final Map<String, String> parameters) {
-        this.gprsOperationModeType = this.getGprsOperationModeType(parameters);
-        this.configurationFlags = new ArrayList<>();
-        final int configurationFlagCount = this.getConfigurationFlagCount(parameters);
-        for (int i = 1; i <= configurationFlagCount; i++) {
-            this.configurationFlags.add(this.getConfigurationFlag(parameters, i));
+        final ConfigurationObject configurationObject = ConfigurationObjectFactory.fromParameterMap(parameters);
+        this.gprsOperationModeType = configurationObject.getGprsOperationMode();
+        if (configurationObject.getConfigurationFlags() != null) {
+            this.configurationFlags = configurationObject.getConfigurationFlags().getConfigurationFlag();
         }
         return this;
     }
 
     public SetConfigurationObjectRequest build() {
-        final ConfigurationFlags configurationFlags = new ConfigurationFlags();
-        configurationFlags.getConfigurationFlag().addAll(this.configurationFlags);
         final ConfigurationObject configurationObject = new ConfigurationObject();
         configurationObject.setGprsOperationMode(this.gprsOperationModeType);
-        configurationObject.setConfigurationFlags(configurationFlags);
+        if (!CollectionUtils.isEmpty(this.configurationFlags)) {
+            final ConfigurationFlags configurationFlagsElement = new ConfigurationFlags();
+            configurationFlagsElement.getConfigurationFlag().addAll(this.configurationFlags);
+            configurationObject.setConfigurationFlags(configurationFlagsElement);
+        }
         final SetConfigurationObjectRequest request = new SetConfigurationObjectRequest();
         request.setConfigurationObject(configurationObject);
         return request;
-    }
-
-    private GprsOperationModeType getGprsOperationModeType(final Map<String, String> parameters) {
-        return getEnum(parameters, PlatformSmartmeteringKeys.GPRS_OPERATION_MODE_TYPE, GprsOperationModeType.class,
-                DEFAULT_GPRS_OPERATION_MODE_TYPE);
-    }
-
-    private int getConfigurationFlagCount(final Map<String, String> parameters) {
-        return getInteger(parameters, PlatformSmartmeteringKeys.CONFIGURATION_FLAG_COUNT,
-                DEFAULT_CONFIGURATION_FLAG_COUNT);
     }
 
     private ConfigurationFlag getDefaultConfigurationFlag() {
@@ -78,22 +65,4 @@ public class SetConfigurationObjectRequestBuilder {
         configurationFlag.setEnabled(DEFAULT_CONFIGURATION_FLAG_ENABLED);
         return configurationFlag;
     }
-
-    private ConfigurationFlag getConfigurationFlag(final Map<String, String> parameters, final int index) {
-        final ConfigurationFlag configurationFlag = new ConfigurationFlag();
-        configurationFlag.setConfigurationFlagType(this.getConfigurationFlagType(parameters, index));
-        configurationFlag.setEnabled(this.getConfigurationFlagEnabled(parameters, index));
-        return configurationFlag;
-    }
-
-    private ConfigurationFlagType getConfigurationFlagType(final Map<String, String> parameters, final int index) {
-        final String key = SettingsHelper.makeKey(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_TYPE, index);
-        return getEnum(parameters, key, ConfigurationFlagType.class, DEFAULT_CONFIGURATION_FLAG_TYPE);
-    }
-
-    private boolean getConfigurationFlagEnabled(final Map<String, String> parameters, final int index) {
-        final String key = SettingsHelper.makeKey(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_ENABLED, index);
-        return getBoolean(parameters, key, DEFAULT_CONFIGURATION_FLAG_ENABLED);
-    }
-
 }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/ConfigurationObjectFactory.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/ConfigurationObjectFactory.java
@@ -8,8 +8,12 @@
 package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.configuration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import org.springframework.util.CollectionUtils;
 
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlag;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlagType;
@@ -24,6 +28,36 @@ public class ConfigurationObjectFactory {
 
     private ConfigurationObjectFactory() {
         // Private constructor for utility class
+    }
+
+    public static ConfigurationObject forGprsOperationModeAndFlags(final GprsOperationModeType gprsOperationMode,
+            final Set<ConfigurationFlagType> enableFlags, final Set<ConfigurationFlagType> disableFlags) {
+
+        final ConfigurationObject configurationObject = new ConfigurationObject();
+        configurationObject.setGprsOperationMode(gprsOperationMode);
+        final List<ConfigurationFlag> configurationFlagList = new ArrayList<>();
+        configurationFlagList.addAll(getFlags(enableFlags, true));
+        configurationFlagList.addAll(getFlags(disableFlags, false));
+        if (!configurationFlagList.isEmpty()) {
+            final ConfigurationFlags configurationFlags = new ConfigurationFlags();
+            configurationFlags.getConfigurationFlag().addAll(configurationFlagList);
+            configurationObject.setConfigurationFlags(configurationFlags);
+        }
+        return configurationObject;
+    }
+
+    private static List<ConfigurationFlag> getFlags(final Set<ConfigurationFlagType> flagTypes, final boolean enabled) {
+        if (CollectionUtils.isEmpty(flagTypes)) {
+            return Collections.emptyList();
+        }
+        final List<ConfigurationFlag> configurationFlags = new ArrayList<>();
+        for (final ConfigurationFlagType flagType : flagTypes) {
+            final ConfigurationFlag configurationFlag = new ConfigurationFlag();
+            configurationFlag.setConfigurationFlagType(flagType);
+            configurationFlag.setEnabled(enabled);
+            configurationFlags.add(configurationFlag);
+        }
+        return configurationFlags;
     }
 
     public static ConfigurationObject fromParameterMap(final Map<String, String> requestParameters) {

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/ConfigurationObjectFactory.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/ConfigurationObjectFactory.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlag;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlagType;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlags;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationObject;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.GprsOperationModeType;
+import com.alliander.osgp.cucumber.core.ReadSettingsHelper;
+import com.alliander.osgp.cucumber.platform.helpers.SettingsHelper;
+import com.alliander.osgp.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
+
+public class ConfigurationObjectFactory {
+
+    private ConfigurationObjectFactory() {
+        // Private constructor for utility class
+    }
+
+    public static ConfigurationObject fromParameterMap(final Map<String, String> requestParameters) {
+        final ConfigurationObject configurationObject = new ConfigurationObject();
+        setConfigurationFlags(configurationObject, requestParameters);
+        configurationObject.setGprsOperationMode(ReadSettingsHelper.getEnum(requestParameters,
+                PlatformSmartmeteringKeys.GPRS_OPERATION_MODE_TYPE, GprsOperationModeType.class));
+        return configurationObject;
+    }
+
+    private static boolean hasConfigurationFlags(final Map<String, String> requestParameters) {
+        return requestParameters.containsKey(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_COUNT);
+    }
+
+    private static void setConfigurationFlags(final ConfigurationObject configurationObject,
+            final Map<String, String> requestParameters) {
+
+        if (!hasConfigurationFlags(requestParameters)) {
+            return;
+        }
+
+        final ConfigurationFlags configurationFlags = new ConfigurationFlags();
+        final List<ConfigurationFlag> configurationFlagList = new ArrayList<>();
+        final int numberOfFlags = Integer
+                .parseInt(requestParameters.get(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_COUNT));
+        for (int i = 1; i <= numberOfFlags; i++) {
+            configurationFlagList.add(getConfigurationFlag(requestParameters, i));
+        }
+        configurationFlags.getConfigurationFlag().addAll(configurationFlagList);
+        configurationObject.setConfigurationFlags(configurationFlags);
+    }
+
+    private static ConfigurationFlag getConfigurationFlag(final Map<String, String> parameters, final int index) {
+        final ConfigurationFlag configurationFlag = new ConfigurationFlag();
+        configurationFlag.setConfigurationFlagType(getConfigurationFlagType(parameters, index));
+        configurationFlag.setEnabled(getConfigurationFlagEnabled(parameters, index));
+        return configurationFlag;
+    }
+
+    private static ConfigurationFlagType getConfigurationFlagType(final Map<String, String> parameters,
+            final int index) {
+
+        final String key = SettingsHelper.makeKey(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_TYPE, index);
+        return ReadSettingsHelper.getEnum(parameters, key, ConfigurationFlagType.class);
+    }
+
+    private static boolean getConfigurationFlagEnabled(final Map<String, String> parameters, final int index) {
+        final String key = SettingsHelper.makeKey(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_ENABLED, index);
+        return ReadSettingsHelper.getBoolean(parameters, key);
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SetConfigurationObjectRequestDataFactory.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SetConfigurationObjectRequestDataFactory.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.configuration;
+
+import java.util.Map;
+
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.SetConfigurationObjectRequestData;
+
+public class SetConfigurationObjectRequestDataFactory {
+
+    private SetConfigurationObjectRequestDataFactory() {
+        // Private constructor for utility class
+    }
+
+    public static SetConfigurationObjectRequestData fromParameterMap(final Map<String, String> requestParameters) {
+        final SetConfigurationObjectRequestData setConfigurationObjectRequestData = new SetConfigurationObjectRequestData();
+        setConfigurationObjectRequestData
+                .setConfigurationObject(ConfigurationObjectFactory.fromParameterMap(requestParameters));
+        return setConfigurationObjectRequestData;
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SetConfigurationObjectRequestFactory.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SetConfigurationObjectRequestFactory.java
@@ -7,22 +7,15 @@
  */
 package com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.configuration;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
-import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlag;
-import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlagType;
-import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlags;
-import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationObject;
-import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.GprsOperationModeType;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.SetConfigurationObjectAsyncRequest;
 import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.SetConfigurationObjectRequest;
-import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.SetConfigurationObjectRequestData;
 import com.alliander.osgp.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.RequestFactoryHelper;
 
 public class SetConfigurationObjectRequestFactory {
+
     private SetConfigurationObjectRequestFactory() {
         // Private constructor for utility class
     }
@@ -32,7 +25,8 @@ public class SetConfigurationObjectRequestFactory {
         setConfigurationObjectRequest
                 .setDeviceIdentification(requestParameters.get(PlatformSmartmeteringKeys.KEY_DEVICE_IDENTIFICATION));
 
-        setConfigurationObjectRequest.setSetConfigurationObjectRequestData(fetchConfigurationObject(requestParameters));
+        setConfigurationObjectRequest.setSetConfigurationObjectRequestData(
+                SetConfigurationObjectRequestDataFactory.fromParameterMap(requestParameters));
 
         return setConfigurationObjectRequest;
     }
@@ -45,31 +39,4 @@ public class SetConfigurationObjectRequestFactory {
                 .setDeviceIdentification(RequestFactoryHelper.getDeviceIdentificationFromScenarioContext());
         return setConfigurationObjectAsyncRequest;
     }
-
-    private static SetConfigurationObjectRequestData fetchConfigurationObject(
-            final Map<String, String> requestParameters) {
-        final ConfigurationObject configurationObject = new ConfigurationObject();
-        final ConfigurationFlags configurationFlags = new ConfigurationFlags();
-
-        final List<ConfigurationFlag> configurationFlagLst = new ArrayList<>();
-        final ConfigurationFlag ConfigurationFlag = new ConfigurationFlag();
-        ConfigurationFlag.setConfigurationFlagType(ConfigurationFlagType
-                .valueOf(requestParameters.get(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_TYPE)));
-
-        ConfigurationFlag.setEnabled(
-                Boolean.parseBoolean(requestParameters.get(PlatformSmartmeteringKeys.CONFIGURATION_FLAG_ENABLED)));
-        configurationFlagLst.add(ConfigurationFlag);
-
-        configurationFlags.getConfigurationFlag().addAll(configurationFlagLst);
-
-        configurationObject.setConfigurationFlags(configurationFlags);
-        configurationObject.setGprsOperationMode(GprsOperationModeType
-                .valueOf(requestParameters.get(PlatformSmartmeteringKeys.GPRS_OPERATION_MODE_TYPE)));
-
-        final SetConfigurationObjectRequestData setConfigurationObjectRequestData = new SetConfigurationObjectRequestData();
-        setConfigurationObjectRequestData.setConfigurationObject(configurationObject);
-
-        return setConfigurationObjectRequestData;
-    }
-
 }

--- a/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringConfiguration.feature
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringConfiguration.feature
@@ -4,7 +4,7 @@ Feature: SmartMetering Configuration
   I want to be able to perform SmartMeteringConfiguration operations on a device
   In order to ...
 
-  Background: 
+  Background:
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
@@ -21,15 +21,6 @@ Feature: SmartMetering Configuration
     When the set special days request is received
       | DeviceIdentification | TEST1024000000001 |
     Then the special days should be set on the device
-      | DeviceIdentification | TEST1024000000001 |
-
-  Scenario: Set configuration object on a device
-    When the set configuration object request is received
-      | DeviceIdentification     | TEST1024000000001 |
-      | ConfigurationFlagType    | PO_ENABLE         |
-      | ConfigurationFlagEnabled | TRUE              |
-      | GprsOperationModeType    | ALWAYS_ON         |
-    Then the configuration object should be set on the device
       | DeviceIdentification | TEST1024000000001 |
 
   Scenario: Handle a received alarm notification from a known device

--- a/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/SetConfigurationObject.feature
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/SetConfigurationObject.feature
@@ -1,0 +1,29 @@
+@SmartMetering @Platform @SmartMeteringConfiguration
+Feature: SmartMetering Configuration
+  As a grid operator
+  I want to be able to set elements of the Configuration Object on a device
+  In order to configure how the device can be communicated with
+
+  Background:
+    Given a dlms device
+      | DeviceIdentification | TEST1024000000001 |
+      | DeviceType           | SMART_METER_E     |
+
+  Scenario: Set configuration object on a device
+    When the set configuration object request is received
+      | DeviceIdentification       | TEST1024000000001 |
+      | ConfigurationFlagCount     |                 1 |
+      | ConfigurationFlagType_1    | PO_ENABLE         |
+      | ConfigurationFlagEnabled_1 | true              |
+      | GprsOperationModeType      | ALWAYS_ON         |
+    Then the configuration object should be set on the device
+      | DeviceIdentification | TEST1024000000001 |
+
+  Scenario: Set configuration object on a device without GPRS operation mode
+    When the set configuration object request is received
+      | DeviceIdentification       | TEST1024000000001    |
+      | ConfigurationFlagCount     |                    1 |
+      | ConfigurationFlagType_1    | DISCOVER_ON_POWER_ON |
+      | ConfigurationFlagEnabled_1 | true                 |
+    Then the configuration object should be set on the device
+      | DeviceIdentification | TEST1024000000001 |


### PR DESCRIPTION
* Adds a test scenario for setting the ConfigurationObject without a
  GPRS operation mode as part of the request.
* Moves the SetConfigurationObject related Cucumber tests to a separate
  feature under configuration.
* Refactors the configuration object request builder and factory to deal
  with parts of the input being optional and to be in sync between the
  bundled and the single request.