### PR TITLE
SLIM-833 Fixes issues with unknown notifications from RTU devices

### DIFF
--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/glue/steps/ws/microgrids/notification/NotificationSteps.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/glue/steps/ws/microgrids/notification/NotificationSteps.java
@@ -29,6 +29,14 @@ import cucumber.api.java.en.When;
 public class NotificationSteps extends GlueBase {
 
     private static final int MAX_WAIT_FOR_NOTIFICATION = 65000;
+    /*
+     * Unknown notification means a notification for a correlation UID that has
+     * not been captured earlier on. This might be because it is a device
+     * initiated notification, or a notification about a request initiated from
+     * application code instead of test code as happens when re-establishing an
+     * RTU connection.
+     */
+    private static final int MAX_WAIT_FOR_UNKNOWN_NOTIFICATION = 200000;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NotificationSteps.class);
 
@@ -42,13 +50,13 @@ public class NotificationSteps extends GlueBase {
 
     @Then("^I should receive a notification$")
     public void iShouldReceiveANotification() throws Throwable {
-        LOGGER.info("Waiting for a notification for at most {} milliseconds.", MAX_WAIT_FOR_NOTIFICATION);
+        LOGGER.info("Waiting for a notification for at most {} milliseconds.", MAX_WAIT_FOR_UNKNOWN_NOTIFICATION);
 
-        final Notification notification = this.notificationService.getNotification(MAX_WAIT_FOR_NOTIFICATION,
+        final Notification notification = this.notificationService.getNotification(MAX_WAIT_FOR_UNKNOWN_NOTIFICATION,
                 TimeUnit.MILLISECONDS);
 
         if (notification == null) {
-            fail("Did not receive a notification within the timeout limit of " + MAX_WAIT_FOR_NOTIFICATION
+            fail("Did not receive a notification within the timeout limit of " + MAX_WAIT_FOR_UNKNOWN_NOTIFICATION
                     + " milliseconds.");
         }
 
@@ -64,6 +72,21 @@ public class NotificationSteps extends GlueBase {
         ScenarioContext.current().put(PlatformKeys.KEY_ORGANIZATION_IDENTIFICATION,
                 PlatformDefaults.DEFAULT_ORGANIZATION_IDENTIFICATION);
         ScenarioContext.current().put(PlatformKeys.KEY_USER_NAME, PlatformDefaults.DEFAULT_USER_NAME);
+
+        /*
+         * We did not know for which correlation UID the notification is
+         * received in this implementation. In some scenarios (for instance when
+         * re-establishing the RTU connection) this is because the GetData
+         * request for which the notification is received was not issued from a
+         * test step, in others it may be because the RTU device initiated the
+         * notification without a prior request. In order to retrieve the
+         * response the correlation UID might be used later-on from the scenario
+         * context. This will wait for a notification for the correlation UID
+         * that was stored in this method, which will no longer arrive, unless
+         * the notification service is notified again, which is done in the next
+         * line.
+         */
+        this.notificationService.handleNotification(notification, PlatformDefaults.DEFAULT_ORGANIZATION_IDENTIFICATION);
     }
 
     @Then("^a notification is sent$")

--- a/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/support/ws/microgrids/adhocmanagement/AdHocManagementClient.java
+++ b/cucumber-tests-platform-microgrids/src/test/java/com/alliander/osgp/cucumber/platform/microgrids/support/ws/microgrids/adhocmanagement/AdHocManagementClient.java
@@ -85,18 +85,6 @@ public class AdHocManagementClient extends BaseClient {
     }
 
     private void waitForNotification(final String correlationUid) {
-        if (correlationUid.startsWith("DeviceGenerated")) {
-            /*
-             * A DeviceGenerated correlation UID is never received in an
-             * AsyncResponse to a web service request. Instead it is received in
-             * notifications pushed as a result of some things happening on a
-             * device. If such a notification is known, the response for it is
-             * ready and does not need to be waited for.
-             */
-            LOGGER.info("Not waiting for device generated notification for correlation UID {}.", correlationUid);
-            return;
-        }
-
         LOGGER.info("Waiting for a notification for correlation UID {} for at most {} milliseconds.", correlationUid,
                 this.waitFailMillis);
 


### PR DESCRIPTION
The Microgrids Cucumber scenarios have steps where the received
notification is not for a correlation UID received earlier in an async
response handled by test code.
For device generated notifications the specific text from the start of
the correlation UID was used to be able to have the tests deal with
them.
A similar situation occurs for notifications about requests not
initiated from test code, as with re-establishing device connections.

To deal with both these cases, the old workaround based on the
correlation UID text has been replaced by a change to the step handling
notifications without expectation of a specific correlation UID. In such
cases the notification is offered back to be handled by the notification
service, so that possible requests from following steps to send async
requests will be notified the correlation UID is available.