### PR TITLE
Fixes DLMS ConfigurationObject related tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = development
+	branch = fixes-getconfigurationobject-tests
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = fixes-getconfigurationobject-tests
+	branch = development
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/DeviceSimulatorSteps.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/DeviceSimulatorSteps.java
@@ -11,15 +11,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
 
+import org.apache.commons.codec.binary.Hex;
 import org.openmuc.jdlms.ObisCode;
-import org.openmuc.jdlms.datatypes.DataObject;
 import org.openmuc.jdlms.interfaceclass.InterfaceClass;
 import org.osgp.adapter.protocol.dlms.simulator.trigger.SimulatorTriggerClient;
 import org.osgp.adapter.protocol.dlms.simulator.trigger.SimulatorTriggerClientException;
@@ -29,34 +26,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.alliander.osgp.cucumber.core.GlueBase;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.BigIntegerNode;
-import com.fasterxml.jackson.databind.node.DecimalNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 
 public class DeviceSimulatorSteps extends GlueBase {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceSimulatorSteps.class);
+
+    private static final String GENERIC_ATTRIBUTES_FROM_SCENARIO = "attributes as defined in scenario";
+
     @Autowired
     private SimulatorTriggerClient simulatorTriggerClient;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceSimulatorSteps.class);
-
-    private static final EnumSet<DataObject.Type> DATA_OBJECT_NO_VALUE_TYPES = EnumSet.of(DataObject.Type.DONT_CARE,
-            DataObject.Type.NULL_DATA);
-
-    private static final EnumSet<DataObject.Type> DATA_OBJECT_INTEGER_VALUE_TYPES = EnumSet.of(DataObject.Type.BCD,
-            DataObject.Type.ENUMERATE, DataObject.Type.INTEGER, DataObject.Type.UNSIGNED, DataObject.Type.LONG_INTEGER,
-            DataObject.Type.LONG_UNSIGNED, DataObject.Type.DOUBLE_LONG, DataObject.Type.DOUBLE_LONG_UNSIGNED,
-            DataObject.Type.LONG64, DataObject.Type.LONG64_UNSIGNED);
-
-    private static final EnumSet<DataObject.Type> DATA_OBJECT_DECIMAL_VALUE_TYPES = EnumSet.of(DataObject.Type.FLOAT32,
-            DataObject.Type.FLOAT64);
+    @Autowired
+    private JsonObjectCreator jsonObjectCreator;
 
     public void clearDlmsAttributeValues() {
         try {
@@ -67,19 +52,66 @@ public class DeviceSimulatorSteps extends GlueBase {
         }
     }
 
-    @Given("^device \"([^\"]*)\" has some alarms registered$")
-    public void deviceHasSomeAlarmsRegistered(final String deviceIdentification) {
-        final ObisCode obisCodeAlarmObject = new ObisCode(0, 0, 97, 98, 0, 255);
-        final ObjectNode attributeValues = this
-                .convertTableToJsonObject(Arrays.asList(Arrays.asList("2", "double-long-unsigned", "33693956")));
+    public ObjectNode getDlmsAttributeValues(final int classId, final ObisCode obisCode, final String description) {
+        ObjectNode jsonAttributeValues = null;
         try {
-            this.simulatorTriggerClient.setDlmsAttributeValues(InterfaceClass.DATA.id(), obisCodeAlarmObject,
-                    attributeValues);
+            jsonAttributeValues = this.simulatorTriggerClient.getDlmsAttributeValues(classId, obisCode);
         } catch (final SimulatorTriggerClientException stce) {
-            LOGGER.error("Error while setting DLMS attribute values for alarm object with SimulatorTriggerClient",
-                    stce);
-            fail("Error setting DLMS attribute values for the alarm object on the simulator");
+            LOGGER.error(
+                    "Error while getting DLMS attribute values with classId: {} and ObisCode: {} for {} with SimulatorTriggerClient",
+                    classId, obisCode, description, stce);
+            fail("Error getting DLMS attribute values for " + description + " on the simulator");
         }
+        return jsonAttributeValues;
+    }
+
+    public ObjectNode getDlmsAttributeValue(final int classId, final ObisCode obisCode, final int attributeId,
+            final String description) {
+        ObjectNode jsonAttributeValue = null;
+        try {
+            jsonAttributeValue = this.simulatorTriggerClient.getDlmsAttributeValue(classId, obisCode, attributeId);
+        } catch (final SimulatorTriggerClientException stce) {
+            LOGGER.error(
+                    "Error while getting DLMS attribute value with classId: {}, ObisCode: {} and attributeId: {} for {} with SimulatorTriggerClient",
+                    classId, obisCode, attributeId, description, stce);
+            fail("Error getting DLMS attribute value for " + description + " on the simulator");
+        }
+        return jsonAttributeValue;
+    }
+
+    public void setDlmsAttributeValues(final int classId, final ObisCode obisCode, final ObjectNode jsonAttributeValues,
+            final String description) {
+
+        try {
+            this.simulatorTriggerClient.setDlmsAttributeValues(classId, obisCode, jsonAttributeValues);
+        } catch (final SimulatorTriggerClientException stce) {
+            LOGGER.error(
+                    "Error while setting DLMS attribute values {} with classId: {} and ObisCode: {} for {} with SimulatorTriggerClient",
+                    jsonAttributeValues, classId, obisCode, description, stce);
+            fail("Error setting DLMS attribute values for " + description + " on the simulator");
+        }
+    }
+
+    public void setDlmsAttributeValue(final int classId, final ObisCode obisCode, final int attributeId,
+            final ObjectNode jsonAttributeValue, final String description) {
+
+        try {
+            this.simulatorTriggerClient.setDlmsAttributeValue(classId, obisCode, attributeId, jsonAttributeValue);
+        } catch (final SimulatorTriggerClientException stce) {
+            LOGGER.error(
+                    "Error while setting DLMS attribute value {} with classId: {}, ObisCode: {}, and attributeId: {} for {} with SimulatorTriggerClient",
+                    jsonAttributeValue, classId, obisCode, attributeId, description, stce);
+            fail("Error setting DLMS attribute value for " + description + " on the simulator");
+        }
+    }
+
+    public void deviceSimulationOfEquipmentIdentifier(final String deviceIdentification) {
+        final ObisCode obisCodeEquipmentIdentifier = new ObisCode(0, 0, 96, 1, 1, 255);
+        final ObjectNode attributeValues = this.jsonObjectCreator
+                .convertTableToJsonObject(Arrays.asList(Arrays.asList("2", "octet-string",
+                        Hex.encodeHexString(deviceIdentification.getBytes(StandardCharsets.US_ASCII)))));
+        this.setDlmsAttributeValues(InterfaceClass.DATA.id(), obisCodeEquipmentIdentifier, attributeValues,
+                "the E-meter Equipment Identifier");
     }
 
     @Given("^device simulation of \"([^\"]*)\" with classid (\\d+) obiscode \"([^\"]*)\" and attributes$")
@@ -96,108 +128,28 @@ public class DeviceSimulatorSteps extends GlueBase {
          * parameter can be used to make this distinction.
          */
 
-        try {
-            this.simulatorTriggerClient.setDlmsAttributeValues(classId, new ObisCode(obisCode),
-                    this.convertTableToJsonObject(attributes));
-        } catch (final SimulatorTriggerClientException stce) {
-            LOGGER.error("Error while setting DLMS attribute values for classId: " + classId + ", obisCode: " + obisCode
-                    + " and attributes: " + attributes + " with SimulatorTriggerClient", stce);
-            fail("Error setting DLMS attribute values for simulator");
-        }
-    }
+        this.deviceSimulationOfEquipmentIdentifier(deviceIdentification);
 
-    private ObjectNode convertTableToJsonObject(final List<List<String>> tableRows) {
-
-        final JsonNodeFactory jsonNodeFactory = new JsonNodeFactory(false);
-        final ObjectNode attributeValues = jsonNodeFactory.objectNode();
-
-        if (tableRows == null) {
-            return attributeValues;
-        }
-
-        for (final List<String> tableRow : tableRows) {
-            this.setAttributeValueFromTableRow(attributeValues, tableRow, jsonNodeFactory);
-        }
-
-        return attributeValues;
-    }
-
-    private void setAttributeValueFromTableRow(final ObjectNode attributeValues,
-            final List<String> valuesForAttributeNode, final JsonNodeFactory jsonNodeFactory) {
-
-        final String attributeId = valuesForAttributeNode.get(0);
-        final String type = valuesForAttributeNode.get(1);
-        final String textValue = valuesForAttributeNode.get(2);
-
-        final ObjectNode attributeValue = this.createAttributeValue(type, textValue, jsonNodeFactory);
-        attributeValues.set(attributeId, attributeValue);
-    }
-
-    private ObjectNode createAttributeValue(final String type, final String textValue,
-            final JsonNodeFactory jsonNodeFactory) {
-
-        final ObjectNode attributeValue = jsonNodeFactory.objectNode();
-        this.setTypeNode(attributeValue, type);
-        this.setValueNode(attributeValue, type, textValue);
-
-        return attributeValue;
-    }
-
-    private void setTypeNode(final ObjectNode attributeValue, final String type) {
-        attributeValue.set("type", TextNode.valueOf(type));
-    }
-
-    private void setValueNode(final ObjectNode attributeValue, final String type, final String textValue) {
-        final DataObject.Type dataObjectType = DataObject.Type.valueOf(type.replace('-', '_').toUpperCase(Locale.UK));
-        if (DATA_OBJECT_NO_VALUE_TYPES.contains(dataObjectType)) {
-            return;
-        }
-        JsonNode valueNode;
-        if (DATA_OBJECT_INTEGER_VALUE_TYPES.contains(dataObjectType)) {
-            valueNode = this.createIntegerNode(new BigInteger(textValue));
-        } else if (DATA_OBJECT_DECIMAL_VALUE_TYPES.contains(dataObjectType)) {
-            valueNode = DecimalNode.valueOf(new BigDecimal(textValue));
-        } else {
-            valueNode = TextNode.valueOf(textValue);
-        }
-        attributeValue.set("value", valueNode);
-    }
-
-    private JsonNode createIntegerNode(final BigInteger value) {
-        try {
-            return IntNode.valueOf(value.intValueExact());
-        } catch (final ArithmeticException e) {
-            return this.createLongIntegerNode(value);
-        }
-    }
-
-    private JsonNode createLongIntegerNode(final BigInteger value) {
-        try {
-            return LongNode.valueOf(value.longValueExact());
-        } catch (final ArithmeticException e) {
-            return BigIntegerNode.valueOf(value);
-        }
+        this.setDlmsAttributeValues(classId, new ObisCode(obisCode),
+                this.jsonObjectCreator.convertTableToJsonObject(attributes), GENERIC_ATTRIBUTES_FROM_SCENARIO);
     }
 
     @Then("^the values for classid (\\d+) obiscode \"([^\"]*)\" on device simulator \"([^\"]*)\" are$")
     public void theValuesForClassidObiscodeOnDeviceSimulatorAre(final int classId, final String obisCode,
             final String deviceIdentification, final List<List<String>> expectedAttributes) throws Throwable {
 
-        try {
-            final ObjectNode attributeValuesNode = this.simulatorTriggerClient.getDlmsAttributeValues(classId,
-                    new ObisCode(obisCode));
-            final ObjectNode expectedAttributeValuesNode = this.convertTableToJsonObject(expectedAttributes);
+        final ObjectNode attributeValuesNode = this.getDlmsAttributeValues(classId, new ObisCode(obisCode),
+                GENERIC_ATTRIBUTES_FROM_SCENARIO);
+        final ObjectNode expectedAttributeValuesNode = this.jsonObjectCreator
+                .convertTableToJsonObject(expectedAttributes);
 
-            expectedAttributeValuesNode.fields().forEachRemaining(field -> {
-                final String attributeId = field.getKey();
-                final JsonNode expectedAttributeValue = field.getValue();
-                final JsonNode actualAttributeValue = attributeValuesNode.get(attributeId);
-                assertNotNull("a value must be available for attributeId: " + attributeId, actualAttributeValue);
-                assertEquals("value for attributeId: " + attributeId, expectedAttributeValue, actualAttributeValue);
-            });
-        } catch (final SimulatorTriggerClientException stce) {
-            LOGGER.error("Error while getting DLMS attribute values", stce);
-            fail("Error getting DLMS attribute values for simulator");
-        }
+        expectedAttributeValuesNode.fields().forEachRemaining(field -> {
+            final String attributeId = field.getKey();
+            final JsonNode expectedAttributeValue = field.getValue();
+            final JsonNode actualAttributeValue = attributeValuesNode.get(attributeId);
+            assertNotNull("a value must be available for attributeId: " + attributeId, actualAttributeValue);
+            assertEquals("value for attributeId: " + attributeId, expectedAttributeValue, actualAttributeValue);
+        });
     }
+
 }

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/JsonObjectCreator.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/JsonObjectCreator.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.glue.steps.simulator;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+
+import org.openmuc.jdlms.datatypes.DataObject;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+/**
+ * Helper class for Cucumber scenario's with factory methods for JsonNodes as
+ * applicable in communication with the DLMS attribute values resource through
+ * the SimulatorTriggerClient.
+ */
+@Service
+public class JsonObjectCreator {
+
+    private static final EnumSet<DataObject.Type> DATA_OBJECT_NO_VALUE_TYPES = EnumSet.of(DataObject.Type.DONT_CARE,
+            DataObject.Type.NULL_DATA);
+
+    private static final EnumSet<DataObject.Type> DATA_OBJECT_INTEGER_VALUE_TYPES = EnumSet.of(DataObject.Type.BCD,
+            DataObject.Type.ENUMERATE, DataObject.Type.INTEGER, DataObject.Type.UNSIGNED, DataObject.Type.LONG_INTEGER,
+            DataObject.Type.LONG_UNSIGNED, DataObject.Type.DOUBLE_LONG, DataObject.Type.DOUBLE_LONG_UNSIGNED,
+            DataObject.Type.LONG64, DataObject.Type.LONG64_UNSIGNED);
+
+    private static final EnumSet<DataObject.Type> DATA_OBJECT_DECIMAL_VALUE_TYPES = EnumSet.of(DataObject.Type.FLOAT32,
+            DataObject.Type.FLOAT64);
+
+    public ObjectNode convertTableToJsonObject(final List<List<String>> tableRows) {
+
+        final JsonNodeFactory jsonNodeFactory = new JsonNodeFactory(false);
+        final ObjectNode attributeValues = jsonNodeFactory.objectNode();
+
+        if (tableRows == null) {
+            return attributeValues;
+        }
+
+        for (final List<String> tableRow : tableRows) {
+            this.setAttributeValueFromTableRow(attributeValues, tableRow, jsonNodeFactory);
+        }
+
+        return attributeValues;
+    }
+
+    private void setAttributeValueFromTableRow(final ObjectNode attributeValues,
+            final List<String> valuesForAttributeNode, final JsonNodeFactory jsonNodeFactory) {
+
+        final String attributeId = valuesForAttributeNode.get(0);
+        final String type = valuesForAttributeNode.get(1);
+        final String textValue = valuesForAttributeNode.get(2);
+
+        final ObjectNode attributeValue = this.createAttributeValue(type, textValue, jsonNodeFactory);
+        attributeValues.set(attributeId, attributeValue);
+    }
+
+    public ObjectNode createAttributeValue(final String type, final String textValue) {
+        return this.createAttributeValue(type, textValue, new JsonNodeFactory(false));
+    }
+
+    public ObjectNode createAttributeValue(final String type, final String textValue,
+            final JsonNodeFactory jsonNodeFactory) {
+
+        final ObjectNode attributeValue = jsonNodeFactory.objectNode();
+        this.setTypeNode(attributeValue, type);
+        this.setValueNode(attributeValue, type, textValue);
+
+        return attributeValue;
+    }
+
+    public void setTypeNode(final ObjectNode attributeValue, final String type) {
+        attributeValue.set("type", TextNode.valueOf(type));
+    }
+
+    private void setValueNode(final ObjectNode attributeValue, final String type, final String textValue) {
+        final DataObject.Type dataObjectType = DataObject.Type.valueOf(type.replace('-', '_').toUpperCase(Locale.UK));
+        if (DATA_OBJECT_NO_VALUE_TYPES.contains(dataObjectType)) {
+            return;
+        }
+        JsonNode valueNode;
+        if (DATA_OBJECT_INTEGER_VALUE_TYPES.contains(dataObjectType)) {
+            valueNode = this.createIntegerNode(new BigInteger(textValue));
+        } else if (DATA_OBJECT_DECIMAL_VALUE_TYPES.contains(dataObjectType)) {
+            valueNode = DecimalNode.valueOf(new BigDecimal(textValue));
+        } else {
+            valueNode = TextNode.valueOf(textValue);
+        }
+        attributeValue.set("value", valueNode);
+    }
+
+    private JsonNode createIntegerNode(final BigInteger value) {
+        try {
+            return IntNode.valueOf(value.intValueExact());
+        } catch (final ArithmeticException e) {
+            return this.createLongIntegerNode(value);
+        }
+    }
+
+    private JsonNode createLongIntegerNode(final BigInteger value) {
+        try {
+            return LongNode.valueOf(value.longValueExact());
+        } catch (final ArithmeticException e) {
+            return BigIntegerNode.valueOf(value);
+        }
+    }
+
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedAlarmObjectSteps.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedAlarmObjectSteps.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.glue.steps.simulator;
+
+import org.openmuc.jdlms.ObisCode;
+import org.openmuc.jdlms.interfaceclass.InterfaceClass;
+import org.openmuc.jdlms.interfaceclass.attribute.DataAttribute;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import cucumber.api.java.en.Given;
+
+public class SimulatedAlarmObjectSteps {
+
+    private static final int CLASS_ID = InterfaceClass.DATA.id();
+    private static final ObisCode OBIS_CODE = new ObisCode(0, 0, 97, 98, 0, 255);
+    private static final int ATTRIBUTE_ID_VALUE = DataAttribute.VALUE.attributeId();
+    private static final String OBJECT_DESCRIPTION = "the alarm object";
+
+    @Autowired
+    private DeviceSimulatorSteps deviceSimulatorSteps;
+
+    @Autowired
+    private JsonObjectCreator jsonObjectCreator;
+
+    @Given("^device \"([^\"]*)\" has some alarms registered$")
+    public void deviceHasSomeAlarmsRegistered(final String deviceIdentification) {
+        this.deviceSimulatorSteps.deviceSimulationOfEquipmentIdentifier(deviceIdentification);
+
+        final ObjectNode attributeValue = this.jsonObjectCreator.createAttributeValue("double-long-unsigned",
+                "33693956");
+        this.deviceSimulatorSteps.setDlmsAttributeValue(CLASS_ID, OBIS_CODE, ATTRIBUTE_ID_VALUE, attributeValue,
+                OBJECT_DESCRIPTION);
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedConfigurationObjectSteps.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedConfigurationObjectSteps.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2018 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.cucumber.platform.smartmetering.glue.steps.simulator;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.openmuc.jdlms.ObisCode;
+import org.openmuc.jdlms.interfaceclass.InterfaceClass;
+import org.openmuc.jdlms.interfaceclass.attribute.DataAttribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlag;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationFlags;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.ConfigurationObject;
+import com.alliander.osgp.adapter.ws.schema.smartmetering.configuration.GprsOperationModeType;
+import com.alliander.osgp.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.ConfigurationObjectFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+
+public class SimulatedConfigurationObjectSteps {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimulatedConfigurationObjectSteps.class);
+
+    private static final int CLASS_ID = InterfaceClass.DATA.id();
+    private static final ObisCode OBIS_CODE = new ObisCode(0, 1, 94, 31, 3, 255);
+    private static final int ATTRIBUTE_ID_VALUE = DataAttribute.VALUE.attributeId();
+    private static final String OBJECT_DESCRIPTION = "the configuration object";
+
+    @Autowired
+    private DeviceSimulatorSteps deviceSimulatorSteps;
+
+    @Autowired
+    private JsonObjectCreator jsonObjectCreator;
+
+    @Given("device simulation of \"([^\"]*)\" with configuration object")
+    public void deviceSimulationOfConfigurationObject(final String deviceIdentification,
+            final Map<String, String> settings) {
+
+        this.deviceSimulatorSteps.deviceSimulationOfEquipmentIdentifier(deviceIdentification);
+
+        final ConfigurationObject configurationObject = ConfigurationObjectFactory.fromParameterMap(settings);
+        final ObjectNode attributeValue = this.createStructureForConfigurationObject(configurationObject,
+                new JsonNodeFactory(false));
+        this.deviceSimulatorSteps.setDlmsAttributeValue(CLASS_ID, OBIS_CODE, ATTRIBUTE_ID_VALUE, attributeValue,
+                OBJECT_DESCRIPTION);
+    }
+
+    @Then("device simulation of \"([^\"]*)\" should be with configuration object")
+    public void deviceSimulationOfShouldBeWithConfigurationObject(final String deviceIdentification,
+            final Map<String, String> settings) {
+
+        final ConfigurationObject expectedConfigurationObject = ConfigurationObjectFactory.fromParameterMap(settings);
+        final ObjectNode expectedValue = this.createStructureForConfigurationObject(expectedConfigurationObject,
+                new JsonNodeFactory(false));
+
+        final ObjectNode actualValue = this.deviceSimulatorSteps.getDlmsAttributeValue(CLASS_ID, OBIS_CODE,
+                ATTRIBUTE_ID_VALUE, OBJECT_DESCRIPTION);
+
+        assertEquals("Simulated ConfigurationObject value", expectedValue, actualValue);
+    }
+
+    private ObjectNode createStructureForConfigurationObject(final ConfigurationObject configurationObject,
+            final JsonNodeFactory jsonNodeFactory) {
+
+        final ObjectNode structureForConfigurationObject = jsonNodeFactory.objectNode();
+        this.jsonObjectCreator.setTypeNode(structureForConfigurationObject, "structure");
+        final ArrayNode configurationObjectElements = jsonNodeFactory.arrayNode();
+        configurationObjectElements.add(this.createGprsOperationModeForConfigurationObject(
+                configurationObject.getGprsOperationMode(), jsonNodeFactory));
+        configurationObjectElements.add(
+                this.createFlagsForConfigurationObject(configurationObject.getConfigurationFlags(), jsonNodeFactory));
+        structureForConfigurationObject.set("value", configurationObjectElements);
+
+        return structureForConfigurationObject;
+    }
+
+    private ObjectNode createGprsOperationModeForConfigurationObject(final GprsOperationModeType gprsOperationMode,
+            final JsonNodeFactory jsonNodeFactory) {
+
+        String textValue;
+        if (gprsOperationMode == GprsOperationModeType.ALWAYS_ON) {
+            textValue = "1";
+        } else if (gprsOperationMode == GprsOperationModeType.TRIGGERED) {
+            textValue = "2";
+        } else {
+            textValue = "0";
+        }
+        return this.jsonObjectCreator.createAttributeValue("enumerate", textValue, jsonNodeFactory);
+    }
+
+    private JsonNode createFlagsForConfigurationObject(final ConfigurationFlags configurationFlags,
+            final JsonNodeFactory jsonNodeFactory) {
+
+        final int bitStringLength = 16;
+        final char[] flags = new char[bitStringLength];
+        for (int i = 0; i < bitStringLength; i++) {
+            flags[i] = '0';
+        }
+        if (configurationFlags != null && configurationFlags.getConfigurationFlag() != null) {
+            final List<ConfigurationFlag> configurationFlagList = configurationFlags.getConfigurationFlag();
+            for (final ConfigurationFlag configurationFlag : configurationFlagList) {
+                if (configurationFlag.isEnabled()) {
+                    flags[configurationFlag.getConfigurationFlagType().ordinal()] = '1';
+                }
+            }
+        }
+        return this.jsonObjectCreator.createAttributeValue("bit-string", new String(flags), jsonNodeFactory);
+    }
+}

--- a/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetConfigurationObject.java
+++ b/cucumber-tests-platform-smartmetering/src/test/java/com/alliander/osgp/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetConfigurationObject.java
@@ -57,10 +57,6 @@ public class SetConfigurationObject {
         final SetConfigurationObjectResponse setConfigurationObjectResponse = this.smartMeteringConfigurationClient
                 .retrieveSetConfigurationObjectResponse(setConfigurationObjectAsyncRequest);
 
-        LOGGER.info("Set configuration object result is: {}", setConfigurationObjectResponse.getResult());
-
-        assertNotNull("Set configuration object result is null", setConfigurationObjectResponse.getResult());
-        assertEquals("Set configuration object result should be OK", OsgpResultType.OK,
-                setConfigurationObjectResponse.getResult());
+        assertEquals("Set configuration object result", OsgpResultType.OK, setConfigurationObjectResponse.getResult());
     }
 }

--- a/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetConfigurationObject.feature
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetConfigurationObject.feature
@@ -3,10 +3,33 @@ Feature: SmartMetering Bundle - GetConfigurationObject
   As a grid operator 
   I want to retrieve the configuration object from a meter via a bundle request
 
-  Background: 
+  Background: A smart meter with a configuration object expected to be on the device
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+    And device simulation of "TEST1024000000001" with configuration object
+      | GprsOperationModeType       | ALWAYS_ON              |
+      | ConfigurationFlagCount      |                     10 |
+      | ConfigurationFlagType_1     | DISCOVER_ON_OPEN_COVER |
+      | ConfigurationFlagEnabled_1  | false                  |
+      | ConfigurationFlagType_2     | DISCOVER_ON_POWER_ON   |
+      | ConfigurationFlagEnabled_2  | true                   |
+      | ConfigurationFlagType_3     | DYNAMIC_MBUS_ADDRESS   |
+      | ConfigurationFlagEnabled_3  | false                  |
+      | ConfigurationFlagType_4     | PO_ENABLE              |
+      | ConfigurationFlagEnabled_4  | false                  |
+      | ConfigurationFlagType_5     | HLS_3_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_5  | false                  |
+      | ConfigurationFlagType_6     | HLS_4_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_6  | false                  |
+      | ConfigurationFlagType_7     | HLS_5_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_7  | true                   |
+      | ConfigurationFlagType_8     | HLS_3_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_8  | false                  |
+      | ConfigurationFlagType_9     | HLS_4_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_9  | false                  |
+      | ConfigurationFlagType_10    | HLS_5_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_10 | false                  |
 
   Scenario: Get configuration object on a device
     Given a bundle request
@@ -16,3 +39,4 @@ Feature: SmartMetering Bundle - GetConfigurationObject
     Then the bundle response should contain a get configuration object response with values
       | GprsOperationMode    | ALWAYS_ON |
       | DISCOVER_ON_POWER_ON | true      |
+      | HLS_5_ON_P_3_ENABLE  | true      |

--- a/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/SetConfigurationObject.feature
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/SetConfigurationObject.feature
@@ -8,6 +8,29 @@ Feature: SmartMetering Configuration
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+    And device simulation of "TEST1024000000001" with configuration object
+      | GprsOperationModeType       | ALWAYS_ON              |
+      | ConfigurationFlagCount      |                     10 |
+      | ConfigurationFlagType_1     | DISCOVER_ON_OPEN_COVER |
+      | ConfigurationFlagEnabled_1  | false                  |
+      | ConfigurationFlagType_2     | DISCOVER_ON_POWER_ON   |
+      | ConfigurationFlagEnabled_2  | true                   |
+      | ConfigurationFlagType_3     | DYNAMIC_MBUS_ADDRESS   |
+      | ConfigurationFlagEnabled_3  | false                  |
+      | ConfigurationFlagType_4     | PO_ENABLE              |
+      | ConfigurationFlagEnabled_4  | false                  |
+      | ConfigurationFlagType_5     | HLS_3_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_5  | false                  |
+      | ConfigurationFlagType_6     | HLS_4_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_6  | false                  |
+      | ConfigurationFlagType_7     | HLS_5_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_7  | true                   |
+      | ConfigurationFlagType_8     | HLS_3_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_8  | false                  |
+      | ConfigurationFlagType_9     | HLS_4_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_9  | false                  |
+      | ConfigurationFlagType_10    | HLS_5_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_10 | false                  |
 
   Scenario: Set configuration object on a device
     When the set configuration object request is received
@@ -22,6 +45,29 @@ Feature: SmartMetering Configuration
       | GprsOperationModeType      | ALWAYS_ON              |
     Then the configuration object should be set on the device
       | DeviceIdentification | TEST1024000000001 |
+    And device simulation of "TEST1024000000001" should be with configuration object
+      | GprsOperationModeType       | ALWAYS_ON              |
+      | ConfigurationFlagCount      |                     10 |
+      | ConfigurationFlagType_1     | DISCOVER_ON_OPEN_COVER |
+      | ConfigurationFlagEnabled_1  | true                   |
+      | ConfigurationFlagType_2     | DISCOVER_ON_POWER_ON   |
+      | ConfigurationFlagEnabled_2  | true                   |
+      | ConfigurationFlagType_3     | DYNAMIC_MBUS_ADDRESS   |
+      | ConfigurationFlagEnabled_3  | false                  |
+      | ConfigurationFlagType_4     | PO_ENABLE              |
+      | ConfigurationFlagEnabled_4  | false                  |
+      | ConfigurationFlagType_5     | HLS_3_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_5  | false                  |
+      | ConfigurationFlagType_6     | HLS_4_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_6  | false                  |
+      | ConfigurationFlagType_7     | HLS_5_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_7  | true                   |
+      | ConfigurationFlagType_8     | HLS_3_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_8  | false                  |
+      | ConfigurationFlagType_9     | HLS_4_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_9  | false                  |
+      | ConfigurationFlagType_10    | HLS_5_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_10 | false                  |
 
   Scenario: Set configuration object on a device without GPRS operation mode
     When the set configuration object request is received
@@ -31,6 +77,29 @@ Feature: SmartMetering Configuration
       | ConfigurationFlagEnabled_1 | true                 |
     Then the configuration object should be set on the device
       | DeviceIdentification | TEST1024000000001 |
+    And device simulation of "TEST1024000000001" should be with configuration object
+      | GprsOperationModeType       | ALWAYS_ON              |
+      | ConfigurationFlagCount      |                     10 |
+      | ConfigurationFlagType_1     | DISCOVER_ON_OPEN_COVER |
+      | ConfigurationFlagEnabled_1  | false                  |
+      | ConfigurationFlagType_2     | DISCOVER_ON_POWER_ON   |
+      | ConfigurationFlagEnabled_2  | true                   |
+      | ConfigurationFlagType_3     | DYNAMIC_MBUS_ADDRESS   |
+      | ConfigurationFlagEnabled_3  | false                  |
+      | ConfigurationFlagType_4     | PO_ENABLE              |
+      | ConfigurationFlagEnabled_4  | false                  |
+      | ConfigurationFlagType_5     | HLS_3_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_5  | false                  |
+      | ConfigurationFlagType_6     | HLS_4_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_6  | false                  |
+      | ConfigurationFlagType_7     | HLS_5_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_7  | true                   |
+      | ConfigurationFlagType_8     | HLS_3_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_8  | false                  |
+      | ConfigurationFlagType_9     | HLS_4_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_9  | false                  |
+      | ConfigurationFlagType_10    | HLS_5_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_10 | false                  |
 
   Scenario: Set configuration object on a device without configuration flags
     When the set configuration object request is received
@@ -38,3 +107,26 @@ Feature: SmartMetering Configuration
       | GprsOperationModeType      | TRIGGERED            |
     Then the configuration object should be set on the device
       | DeviceIdentification | TEST1024000000001 |
+    And device simulation of "TEST1024000000001" should be with configuration object
+      | GprsOperationModeType       | TRIGGERED              |
+      | ConfigurationFlagCount      |                     10 |
+      | ConfigurationFlagType_1     | DISCOVER_ON_OPEN_COVER |
+      | ConfigurationFlagEnabled_1  | false                  |
+      | ConfigurationFlagType_2     | DISCOVER_ON_POWER_ON   |
+      | ConfigurationFlagEnabled_2  | true                   |
+      | ConfigurationFlagType_3     | DYNAMIC_MBUS_ADDRESS   |
+      | ConfigurationFlagEnabled_3  | false                  |
+      | ConfigurationFlagType_4     | PO_ENABLE              |
+      | ConfigurationFlagEnabled_4  | false                  |
+      | ConfigurationFlagType_5     | HLS_3_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_5  | false                  |
+      | ConfigurationFlagType_6     | HLS_4_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_6  | false                  |
+      | ConfigurationFlagType_7     | HLS_5_ON_P_3_ENABLE    |
+      | ConfigurationFlagEnabled_7  | true                   |
+      | ConfigurationFlagType_8     | HLS_3_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_8  | false                  |
+      | ConfigurationFlagType_9     | HLS_4_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_9  | false                  |
+      | ConfigurationFlagType_10    | HLS_5_ON_PO_ENABLE     |
+      | ConfigurationFlagEnabled_10 | false                  |


### PR DESCRIPTION
Cucumber tests for retrieving the configuration object could fail when
another test setting the configuration object sets unexpected values on
this object earlier in the test run.

Updated BundledGetConfigurationObject feature. The background now sets
the configuration object for the simulator, so it is known what may be
expected to be returned from the calls through the platform. Added
HLS_5_ON_P_3_ENABLE set to true, because it does not make sense for that
flag to be false.

Updated SetConfigurationObject feature. The background now sets
the configuration object for the simulator, so it is known what may be
expected to be on the simulated device after the set actions from the
scenarios.
Adds verification that the simulated configuration object is updated as
expected from the executed set requests.

Added methods for getting or setting a single attribute value to the
DeviceSimulatorSteps to avoid retreiving/creating objects for all
attribute values of a COSEM interface object, when only a single one is
important to the test at hand.
Refactored DeviceSimulatorSteps, which had too many reasons to change.
Code for specific simulated objects is moved to
SimulatedAlarmObjectSteps and SimulatedConfigurationObjectSteps. Code
for creating the JSON objects required for the API calls is moved to
JsonObjectCreator.
Refactored to remove duplication in the error handling around web client
calls.

Removed some redundant logging and asserting from
SetConfigurationObject.

[@SmartMetering]