### PR TITLE
SLIM-1134 Fixes replace keys scenario without functional exception

### DIFF
--- a/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringConfiguration.feature
+++ b/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/SmartMeteringConfiguration.feature
@@ -176,17 +176,6 @@ Feature: SmartMetering Configuration
 
   @ResetKeysOnDevice
   Scenario: Replace keys with generated ones on a device
-    Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
-    And a dlms device
-      | DeviceIdentification           | TESTG102400000001                                                |
-      | DeviceType                     | SMART_METER_G                                                    |
-      | GatewayDeviceIdentification    | TEST1024000000001                                                |
-      | Channel                        |                                                                1 |
-      | MbusIdentificationNumber       |                                                         24000000 |
-      | MbusManufacturerIdentification | LGB                                                              |
-      | MbusUserKey                    | 17ec0e5f6a3314df6239cf9f1b902cbfc9f39e82c57a40ffd8a3e552cc720c92 |
     When the generate and replace keys request is received
       | DeviceIdentification | TEST1024000000001 |
     Then the generate and replace keys response should be returned


### PR DESCRIPTION
The scenario to replace keys with generated ones was copied from the
FunctionalExceptionsEncryptionKeys feature to the
SmartMeteringConfiguration feature because it does not involve a
functional exception.
The given steps to make sure the meter exists were still in the scenario
where they are part of the background of the configuration feature.
This removes the devices from the scenario to prevent JPA exceptions
trying to add them to the database two times.
[@SmartMeteringConfiguration]