### PR TITLE
OC-61 Clean up use of enums with message processors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,20 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = OC-61-Clean-up-use-of-enums-with-message-processors
+	branch = development
 [submodule "Protocol-Adapter-OSLP"]
 	path = Protocol-Adapter-OSLP
 	url = https://github.com/OSGP/Protocol-Adapter-OSLP.git
-	branch = OC-61-Clean-up-use-of-enums-with-message-processors
+	branch = development
 [submodule "Platform"]
 	path = Platform
 	url = https://github.com/OSGP/Platform.git
-	branch = OC-61-Clean-up-use-of-enums-with-message-processors
+	branch = development
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = OC-61-Clean-up-use-of-enums-with-message-processors
+	branch = development
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git
-	branch = OC-61-Clean-up-use-of-enums-with-message-processors
+	branch = development

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,20 @@
 [submodule "Shared"]
 	path = Shared
 	url = https://github.com/OSGP/Shared.git
-	branch = development
+	branch = OC-61-Clean-up-use-of-enums-with-message-processors
 [submodule "Protocol-Adapter-OSLP"]
 	path = Protocol-Adapter-OSLP
 	url = https://github.com/OSGP/Protocol-Adapter-OSLP.git
-	branch = development
+	branch = OC-61-Clean-up-use-of-enums-with-message-processors
 [submodule "Platform"]
 	path = Platform
 	url = https://github.com/OSGP/Platform.git
-	branch = development
+	branch = OC-61-Clean-up-use-of-enums-with-message-processors
 [submodule "Protocol-Adapter-DLMS"]
 	path = Protocol-Adapter-DLMS
 	url = https://github.com/OSGP/Protocol-Adapter-DLMS.git
-	branch = development
+	branch = OC-61-Clean-up-use-of-enums-with-message-processors
 [submodule "Protocol-Adapter-IEC61850"]
 	path = Protocol-Adapter-IEC61850
 	url = https://github.com/OSGP/Protocol-Adapter-IEC61850.git
-	branch = development
+	branch = OC-61-Clean-up-use-of-enums-with-message-processors

--- a/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/mocks/OslpDeviceSteps.java
+++ b/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/mocks/OslpDeviceSteps.java
@@ -28,7 +28,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
-import org.opensmartgridplatform.adapter.protocol.oslp.elster.infra.messaging.DeviceRequestMessageType;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
@@ -72,6 +71,7 @@ import org.opensmartgridplatform.oslp.Oslp.UpdateFirmwareRequest;
 import org.opensmartgridplatform.oslp.Oslp.Weekday;
 import org.opensmartgridplatform.oslp.OslpEnvelope;
 import org.opensmartgridplatform.oslp.OslpUtils;
+import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.CollectionUtils;
 
@@ -94,19 +94,6 @@ public class OslpDeviceSteps {
     private MockOslpServer oslpMockServer;
 
     /**
-     * Verify that a get actual power usage OSLP message is sent to the device.
-     *
-     */
-    @Then("^a get actual power usage OSLP message is sent to the device$")
-    public void aGetActualPowerUsageOslpMessageIsSentToTheDevice() {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.GET_ACTUAL_POWER_USAGE);
-        Assert.assertNotNull(message);
-        Assert.assertTrue(message.hasGetActualPowerUsageRequest());
-
-        message.getGetActualPowerUsageRequest();
-    }
-
-    /**
      * Verify that a get configuration OSLP message is sent to the device.
      *
      * @param deviceIdentification
@@ -115,7 +102,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a get configuration \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aGetConfigurationOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.GET_CONFIGURATION);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.GET_CONFIGURATION);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasGetConfigurationRequest());
     }
@@ -129,7 +116,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a get firmware version \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aGetFirmwareVersionOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.GET_FIRMWARE_VERSION);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.GET_FIRMWARE_VERSION);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasGetFirmwareVersionRequest());
 
@@ -145,7 +132,7 @@ public class OslpDeviceSteps {
     @Then("^a get power usage history \"([^\"]*)\" message is sent to the device$")
     public void aGetPowerUsageHistoryOslpMessageIsSentToTheDevice(final String protocol,
             final Map<String, String> expectedParameters) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.GET_POWER_USAGE_HISTORY);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.GET_POWER_USAGE_HISTORY);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasGetPowerUsageHistoryRequest());
 
@@ -181,7 +168,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a get status \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aGetStatusOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.GET_STATUS);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.GET_STATUS);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasGetStatusRequest());
     }
@@ -195,7 +182,7 @@ public class OslpDeviceSteps {
      */
     @Then("^an update firmware \"([^\"]*)\" message is sent to the device$")
     public void anUpdateFirmwareOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.UPDATE_FIRMWARE);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.UPDATE_FIRMWARE);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasUpdateFirmwareRequest());
 
@@ -204,7 +191,7 @@ public class OslpDeviceSteps {
 
     @Then("^an update key \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void anUpdateKeyOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.UPDATE_KEY);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.UPDATE_KEY);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetDeviceVerificationKeyRequest());
     }
@@ -219,7 +206,7 @@ public class OslpDeviceSteps {
     @Then("^a resume schedule \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aResumeScheduleOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification,
             final Map<String, String> expectedRequest) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.RESUME_SCHEDULE);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.RESUME_SCHEDULE);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasResumeScheduleRequest());
 
@@ -243,7 +230,7 @@ public class OslpDeviceSteps {
     @Then("^a set configuration \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aSetConfigurationOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification,
             final Map<String, String> expectedResponseData) {
-        final Message receivedMessage = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.SET_CONFIGURATION);
+        final Message receivedMessage = this.oslpMockServer.waitForRequest(MessageType.SET_CONFIGURATION);
         Assert.assertNotNull(receivedMessage);
         Assert.assertTrue(receivedMessage.hasSetConfigurationRequest());
 
@@ -402,7 +389,7 @@ public class OslpDeviceSteps {
     @Then("^a set event notification \"([^\"]*)\" message is sent to device \"([^\"]*)\"")
     public void aSetEventNotificationOslpMessageIsSentToDevice(final String protocol,
             final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.SET_EVENT_NOTIFICATIONS);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.SET_EVENT_NOTIFICATIONS);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetEventNotificationsRequest());
     }
@@ -415,7 +402,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a set light \"([^\"]*)\" message with \"([^\"]*)\" lightvalues is sent to the device$")
     public void aSetLightOslpMessageWithLightValuesIsSentToTheDevice(final String protocol, final int nofLightValues) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.SET_LIGHT);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.SET_LIGHT);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetLightRequest());
 
@@ -431,7 +418,7 @@ public class OslpDeviceSteps {
     @Then("^a set light \"([^\"]*)\" message with one light value is sent to the device$")
     public void aSetLightOSLPMessageWithOneLightvalueIsSentToTheDevice(final String protocol,
             final Map<String, String> expectedParameters) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.SET_LIGHT);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.SET_LIGHT);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetLightRequest());
 
@@ -462,7 +449,7 @@ public class OslpDeviceSteps {
     @Then("^a set light schedule \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aSetLightScheduleOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification,
             final Map<String, String> expectedRequest) {
-        this.checkAndValidateRequest(DeviceRequestMessageType.SET_LIGHT_SCHEDULE, expectedRequest);
+        this.checkAndValidateRequest(MessageType.SET_LIGHT_SCHEDULE, expectedRequest);
     }
 
     /**
@@ -474,7 +461,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a set reboot \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aSetRebootOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.SET_REBOOT);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.SET_REBOOT);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetRebootRequest());
 
@@ -508,7 +495,7 @@ public class OslpDeviceSteps {
     @Then("^a set tariff schedule \"([^\"]*)\" message is sent to device \"(?:([^\"]*))\"$")
     public void aSetTariffScheduleOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification,
             final Map<String, String> expectedRequest) {
-        this.checkAndValidateRequest(DeviceRequestMessageType.SET_TARIFF_SCHEDULE, expectedRequest);
+        this.checkAndValidateRequest(MessageType.SET_TARIFF_SCHEDULE, expectedRequest);
     }
 
     /**
@@ -521,7 +508,7 @@ public class OslpDeviceSteps {
     @Then("^a set transition \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aSetTransitionOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification,
             final Map<String, String> expectedResult) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.SET_TRANSITION);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.SET_TRANSITION);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetTransitionRequest());
 
@@ -546,7 +533,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a start device \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aStartDeviceOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.START_SELF_TEST);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.START_SELF_TEST);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasStartSelfTestRequest());
     }
@@ -560,7 +547,7 @@ public class OslpDeviceSteps {
      */
     @Then("^a stop device \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void aStopDeviceOSLPMessageIsSentToDevice(final String protocol, final String deviceIdentification) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.STOP_SELF_TEST);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.STOP_SELF_TEST);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasStopSelfTestRequest());
     }
@@ -568,12 +555,11 @@ public class OslpDeviceSteps {
     /**
      * Setup method to get a status which should be returned by the mock.
      */
-    private void callMockSetScheduleResponse(final String result, final DeviceRequestMessageType type) {
+    private void callMockSetScheduleResponse(final String result, final MessageType type) {
         this.oslpMockServer.mockSetScheduleResponse(type, Enum.valueOf(Status.class, result));
     }
 
-    private void checkAndValidateRequest(final DeviceRequestMessageType type,
-            final Map<String, String> expectedRequest) {
+    private void checkAndValidateRequest(final MessageType type, final Map<String, String> expectedRequest) {
         final Message message = this.oslpMockServer.waitForRequest(type);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasSetScheduleRequest());
@@ -581,7 +567,7 @@ public class OslpDeviceSteps {
         final SetScheduleRequest request = message.getSetScheduleRequest();
 
         for (final Schedule schedule : request.getSchedulesList()) {
-            if (type == DeviceRequestMessageType.SET_LIGHT_SCHEDULE) {
+            if (type == MessageType.SET_LIGHT_SCHEDULE) {
                 Assert.assertEquals(
                         getEnum(expectedRequest, PlatformPubliclightingKeys.SCHEDULE_WEEKDAY, Weekday.class),
                         schedule.getWeekday());
@@ -599,7 +585,7 @@ public class OslpDeviceSteps {
                 Assert.assertEquals(endDay, schedule.getEndDay());
             }
 
-            if (type == DeviceRequestMessageType.SET_LIGHT_SCHEDULE) {
+            if (type == MessageType.SET_LIGHT_SCHEDULE) {
                 Assert.assertEquals(
                         getEnum(expectedRequest, PlatformPubliclightingKeys.SCHEDULE_ACTIONTIME, ActionTime.class),
                         schedule.getActionTime());
@@ -613,24 +599,23 @@ public class OslpDeviceSteps {
                 Assert.assertEquals(expectedTime, schedule.getTime());
             }
             final String scheduleLightValue = getString(expectedRequest,
-                    (type == DeviceRequestMessageType.SET_LIGHT_SCHEDULE)
-                            ? PlatformPubliclightingKeys.SCHEDULE_LIGHTVALUES
+                    (type == MessageType.SET_LIGHT_SCHEDULE) ? PlatformPubliclightingKeys.SCHEDULE_LIGHTVALUES
                             : PlatformPubliclightingKeys.SCHEDULE_TARIFFVALUES);
             final String[] scheduleLightValues = scheduleLightValue.split(";");
             Assert.assertEquals(scheduleLightValues.length, schedule.getValueCount());
             for (int i = 0; i < scheduleLightValues.length; i++) {
                 final Integer index = OslpUtils.byteStringToInteger(schedule.getValue(i).getIndex()),
                         dimValue = OslpUtils.byteStringToInteger(schedule.getValue(i).getDimValue());
-                if (type == DeviceRequestMessageType.SET_LIGHT_SCHEDULE) {
+                if (type == MessageType.SET_LIGHT_SCHEDULE) {
                     Assert.assertEquals(scheduleLightValues[i], String.format("%s,%s,%s", (index != null) ? index : "",
                             schedule.getValue(i).getOn(), (dimValue != null) ? dimValue : ""));
-                } else if (type == DeviceRequestMessageType.SET_TARIFF_SCHEDULE) {
+                } else if (type == MessageType.SET_TARIFF_SCHEDULE) {
                     Assert.assertEquals(scheduleLightValues[i],
                             String.format("%s,%s", (index != null) ? index : "", !schedule.getValue(i).getOn()));
                 }
             }
 
-            if (type == DeviceRequestMessageType.SET_LIGHT_SCHEDULE) {
+            if (type == MessageType.SET_LIGHT_SCHEDULE) {
                 Assert.assertEquals(
                         (!getString(expectedRequest, PlatformPubliclightingKeys.SCHEDULE_TRIGGERTYPE).isEmpty())
                                 ? getEnum(expectedRequest, PlatformPubliclightingKeys.SCHEDULE_TRIGGERTYPE,
@@ -674,47 +659,6 @@ public class OslpDeviceSteps {
 
         // Save the OSLP response for later validation.
         ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE, this.oslpMockServer.sendRequest(message));
-    }
-
-    /**
-     * Setup method to get an actual power usage which should be returned by the
-     * mock.
-     *
-     * @param responseData
-     *            The data to respond.
-     */
-    @Given("^the device returns a get actual power usage response \"([^\"]*)\" over OSLP$")
-    public void theDeviceReturnsAGetActualPowerUsageOverOSLP(final String result,
-            final Map<String, String> responseData) {
-
-        // Note: This piece of code has been made because there are multiple
-        // enumerations with the name MeterType, but not all of them has all
-        // values the same. Some with underscore and some without.
-        MeterType meterType;
-        final String sMeterType = getString(responseData, PlatformPubliclightingKeys.METER_TYPE);
-        if (!sMeterType.contains("_") && sMeterType.equals(MeterType.P1_VALUE)) {
-            final String[] sMeterTypeArray = sMeterType.split("");
-            meterType = MeterType.valueOf(sMeterTypeArray[0] + "_" + sMeterTypeArray[1]);
-        } else {
-            meterType = getEnum(responseData, PlatformPubliclightingKeys.METER_TYPE, MeterType.class);
-        }
-
-        this.oslpMockServer.mockGetActualPowerUsageResponse(Enum.valueOf(Status.class, result),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_CONSUMED_POWER, null), meterType,
-                getDate(responseData, PlatformPubliclightingKeys.RECORD_TIME).toDateTime(DateTimeZone.UTC)
-                        .toString("yyyyMMddHHmmss"),
-                getInteger(responseData, PlatformPubliclightingKeys.TOTAL_CONSUMED_ENERGY, null),
-                getInteger(responseData, PlatformPubliclightingKeys.TOTAL_LIGHTING_HOURS, null),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_CURRENT1, null),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_CURRENT2, null),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_CURRENT3, null),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_POWER1, null),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_POWER2, null),
-                getInteger(responseData, PlatformPubliclightingKeys.ACTUAL_POWER3, null),
-                getInteger(responseData, PlatformPubliclightingKeys.AVERAGE_POWER_FACTOR1, null),
-                getInteger(responseData, PlatformPubliclightingKeys.AVERAGE_POWER_FACTOR2, null),
-                getInteger(responseData, PlatformPubliclightingKeys.AVERAGE_POWER_FACTOR3, null),
-                getString(responseData, PlatformPubliclightingKeys.RELAY_DATA, null));
     }
 
     @Given("^the device returns a get configuration status over \"([^\"]*)\"$")
@@ -908,7 +852,7 @@ public class OslpDeviceSteps {
      */
     @Given("^the device returns a set light schedule response \"([^\"]*)\" over \"([^\"]*)\"$")
     public void theDeviceReturnsASetLightScheduleResponseOverOSLP(final String result, final String protocol) {
-        this.callMockSetScheduleResponse(result, DeviceRequestMessageType.SET_LIGHT_SCHEDULE);
+        this.callMockSetScheduleResponse(result, MessageType.SET_LIGHT_SCHEDULE);
     }
 
     /**
@@ -926,7 +870,7 @@ public class OslpDeviceSteps {
 
     @Given("^the device returns a set tariff schedule response \"([^\"]*)\" over \"([^\"]*)\"$")
     public void theDeviceReturnsASetTariffScheduleResponseOverOSLP(final String result, final String protocol) {
-        this.callMockSetScheduleResponse(result, DeviceRequestMessageType.SET_TARIFF_SCHEDULE);
+        this.callMockSetScheduleResponse(result, MessageType.SET_TARIFF_SCHEDULE);
     }
 
     /**
@@ -1185,7 +1129,7 @@ public class OslpDeviceSteps {
     @Then("^an update firmware \"([^\"]*)\" message is sent to device \"([^\"]*)\"$")
     public void anUpdateFirmwareOSLPMessageIsSentToTheDevice(final String protocol, final String deviceIdentification,
             final Map<String, String> expectedParameters) {
-        final Message message = this.oslpMockServer.waitForRequest(DeviceRequestMessageType.UPDATE_FIRMWARE);
+        final Message message = this.oslpMockServer.waitForRequest(MessageType.UPDATE_FIRMWARE);
         Assert.assertNotNull(message);
         Assert.assertTrue(message.hasUpdateFirmwareRequest());
 

--- a/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/mocks/oslpdevice/MockOslpChannelHandler.java
+++ b/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/mocks/oslpdevice/MockOslpChannelHandler.java
@@ -29,16 +29,15 @@ import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelHandler;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.annotation.Transient;
-
-import org.opensmartgridplatform.adapter.protocol.oslp.elster.infra.messaging.DeviceRequestMessageType;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.opensmartgridplatform.oslp.Oslp;
 import org.opensmartgridplatform.oslp.Oslp.Message;
 import org.opensmartgridplatform.oslp.OslpEnvelope;
+import org.opensmartgridplatform.shared.infra.jms.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.annotation.Transient;
 
 public class MockOslpChannelHandler extends SimpleChannelHandler {
 
@@ -107,7 +106,7 @@ public class MockOslpChannelHandler extends SimpleChannelHandler {
     private final ClientBootstrap clientBootstrap;
     private final int connectionTimeout;
     private final Lock lock = new ReentrantLock();
-    private final ConcurrentMap<DeviceRequestMessageType, Message> mockResponses;
+    private final ConcurrentMap<MessageType, Message> mockResponses;
     private final String oslpSignature;
 
     private final String oslpSignatureProvider;
@@ -118,7 +117,7 @@ public class MockOslpChannelHandler extends SimpleChannelHandler {
 
     private final Random random = new Random();
 
-    private final ConcurrentMap<DeviceRequestMessageType, Message> receivedRequests;
+    private final ConcurrentMap<MessageType, Message> receivedRequests;
     private final List<Message> receivedResponses;
 
     private final Long reponseDelayRandomRange;
@@ -132,9 +131,8 @@ public class MockOslpChannelHandler extends SimpleChannelHandler {
     public MockOslpChannelHandler(final String oslpSignature, final String oslpSignatureProvider,
             final int connectionTimeout, final Integer sequenceNumberWindow, final Integer sequenceNumberMaximum,
             final Long responseDelayTime, final Long reponseDelayRandomRange, final PrivateKey privateKey,
-            final ClientBootstrap clientBootstrap, final ConcurrentMap<DeviceRequestMessageType, Message> mockResponses,
-            final ConcurrentMap<DeviceRequestMessageType, Message> receivedRequests,
-            final List<Message> receivedResponses) {
+            final ClientBootstrap clientBootstrap, final ConcurrentMap<MessageType, Message> mockResponses,
+            final ConcurrentMap<MessageType, Message> receivedRequests, final List<Message> receivedResponses) {
         this.oslpSignature = oslpSignature;
         this.oslpSignatureProvider = oslpSignatureProvider;
         this.connectionTimeout = connectionTimeout;
@@ -183,7 +181,7 @@ public class MockOslpChannelHandler extends SimpleChannelHandler {
         e.getChannel().close();
     }
 
-    public ConcurrentMap<DeviceRequestMessageType, Message> getMap() {
+    public ConcurrentMap<MessageType, Message> getMap() {
         return this.mockResponses;
     }
 
@@ -366,58 +364,47 @@ public class MockOslpChannelHandler extends SimpleChannelHandler {
 
         // Handle requests
         if (request.hasGetFirmwareVersionRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.GET_FIRMWARE_VERSION)) {
-            response = this.processRequest(DeviceRequestMessageType.GET_FIRMWARE_VERSION, request);
-        } else if (request.hasUpdateFirmwareRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.UPDATE_FIRMWARE)) {
-            response = this.processRequest(DeviceRequestMessageType.UPDATE_FIRMWARE, request);
-        } else if (request.hasSetLightRequest() && this.mockResponses.containsKey(DeviceRequestMessageType.SET_LIGHT)) {
-            response = this.processRequest(DeviceRequestMessageType.SET_LIGHT, request);
+                && this.mockResponses.containsKey(MessageType.GET_FIRMWARE_VERSION)) {
+            response = this.processRequest(MessageType.GET_FIRMWARE_VERSION, request);
+        } else if (request.hasUpdateFirmwareRequest() && this.mockResponses.containsKey(MessageType.UPDATE_FIRMWARE)) {
+            response = this.processRequest(MessageType.UPDATE_FIRMWARE, request);
+        } else if (request.hasSetLightRequest() && this.mockResponses.containsKey(MessageType.SET_LIGHT)) {
+            response = this.processRequest(MessageType.SET_LIGHT, request);
         } else if (request.hasSetEventNotificationsRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.SET_EVENT_NOTIFICATIONS)) {
-            response = this.processRequest(DeviceRequestMessageType.SET_EVENT_NOTIFICATIONS, request);
-        } else if (request.hasStartSelfTestRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.START_SELF_TEST)) {
-            response = this.processRequest(DeviceRequestMessageType.START_SELF_TEST, request);
-        } else if (request.hasStopSelfTestRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.STOP_SELF_TEST)) {
-            response = this.processRequest(DeviceRequestMessageType.STOP_SELF_TEST, request);
-        } else if (request.hasGetStatusRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.GET_STATUS)) {
-            response = this.processRequest(DeviceRequestMessageType.GET_STATUS, request);
-        } else if (request.hasGetStatusRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.GET_LIGHT_STATUS)) {
-            response = this.processRequest(DeviceRequestMessageType.GET_LIGHT_STATUS, request);
-        } else if (request.hasResumeScheduleRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.RESUME_SCHEDULE)) {
-            response = this.processRequest(DeviceRequestMessageType.RESUME_SCHEDULE, request);
-        } else if (request.hasSetRebootRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.SET_REBOOT)) {
-            response = this.processRequest(DeviceRequestMessageType.SET_REBOOT, request);
-        } else if (request.hasSetTransitionRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.SET_TRANSITION)) {
-            response = this.processRequest(DeviceRequestMessageType.SET_TRANSITION, request);
+                && this.mockResponses.containsKey(MessageType.SET_EVENT_NOTIFICATIONS)) {
+            response = this.processRequest(MessageType.SET_EVENT_NOTIFICATIONS, request);
+        } else if (request.hasStartSelfTestRequest() && this.mockResponses.containsKey(MessageType.START_SELF_TEST)) {
+            response = this.processRequest(MessageType.START_SELF_TEST, request);
+        } else if (request.hasStopSelfTestRequest() && this.mockResponses.containsKey(MessageType.STOP_SELF_TEST)) {
+            response = this.processRequest(MessageType.STOP_SELF_TEST, request);
+        } else if (request.hasGetStatusRequest() && this.mockResponses.containsKey(MessageType.GET_STATUS)) {
+            response = this.processRequest(MessageType.GET_STATUS, request);
+        } else if (request.hasGetStatusRequest() && this.mockResponses.containsKey(MessageType.GET_LIGHT_STATUS)) {
+            response = this.processRequest(MessageType.GET_LIGHT_STATUS, request);
+        } else if (request.hasResumeScheduleRequest() && this.mockResponses.containsKey(MessageType.RESUME_SCHEDULE)) {
+            response = this.processRequest(MessageType.RESUME_SCHEDULE, request);
+        } else if (request.hasSetRebootRequest() && this.mockResponses.containsKey(MessageType.SET_REBOOT)) {
+            response = this.processRequest(MessageType.SET_REBOOT, request);
+        } else if (request.hasSetTransitionRequest() && this.mockResponses.containsKey(MessageType.SET_TRANSITION)) {
+            response = this.processRequest(MessageType.SET_TRANSITION, request);
         } else if (request.hasSetDeviceVerificationKeyRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.UPDATE_KEY)) {
-            response = this.processRequest(DeviceRequestMessageType.UPDATE_KEY, request);
-        } else if (request.hasGetActualPowerUsageRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.GET_ACTUAL_POWER_USAGE)) {
-            response = this.processRequest(DeviceRequestMessageType.GET_ACTUAL_POWER_USAGE, request);
+                && this.mockResponses.containsKey(MessageType.UPDATE_KEY)) {
+            response = this.processRequest(MessageType.UPDATE_KEY, request);
         } else if (request.hasGetPowerUsageHistoryRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.GET_POWER_USAGE_HISTORY)) {
-            response = this.processRequest(DeviceRequestMessageType.GET_POWER_USAGE_HISTORY, request);
+                && this.mockResponses.containsKey(MessageType.GET_POWER_USAGE_HISTORY)) {
+            response = this.processRequest(MessageType.GET_POWER_USAGE_HISTORY, request);
         } else if (request.hasSetScheduleRequest()) {
-            if (this.mockResponses.containsKey(DeviceRequestMessageType.SET_LIGHT_SCHEDULE)) {
-                response = this.processRequest(DeviceRequestMessageType.SET_LIGHT_SCHEDULE, request);
-            } else if (this.mockResponses.containsKey(DeviceRequestMessageType.SET_TARIFF_SCHEDULE)) {
-                response = this.processRequest(DeviceRequestMessageType.SET_TARIFF_SCHEDULE, request);
+            if (this.mockResponses.containsKey(MessageType.SET_LIGHT_SCHEDULE)) {
+                response = this.processRequest(MessageType.SET_LIGHT_SCHEDULE, request);
+            } else if (this.mockResponses.containsKey(MessageType.SET_TARIFF_SCHEDULE)) {
+                response = this.processRequest(MessageType.SET_TARIFF_SCHEDULE, request);
             }
         } else if (request.hasGetConfigurationRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.GET_CONFIGURATION)) {
-            response = this.processRequest(DeviceRequestMessageType.GET_CONFIGURATION, request);
+                && this.mockResponses.containsKey(MessageType.GET_CONFIGURATION)) {
+            response = this.processRequest(MessageType.GET_CONFIGURATION, request);
         } else if (request.hasSetConfigurationRequest()
-                && this.mockResponses.containsKey(DeviceRequestMessageType.SET_CONFIGURATION)) {
-            response = this.processRequest(DeviceRequestMessageType.SET_CONFIGURATION, request);
+                && this.mockResponses.containsKey(MessageType.SET_CONFIGURATION)) {
+            response = this.processRequest(MessageType.SET_CONFIGURATION, request);
         }
         // TODO: Implement further requests.
         else {
@@ -431,7 +418,7 @@ public class MockOslpChannelHandler extends SimpleChannelHandler {
         return response;
     }
 
-    private Oslp.Message processRequest(final DeviceRequestMessageType type, final Oslp.Message request) {
+    private Oslp.Message processRequest(final MessageType type, final Oslp.Message request) {
         Oslp.Message response;
 
         LOGGER.debug("Processing [{}] ...", type.name());

--- a/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/mocks/oslpdevice/MockOslpServer.java
+++ b/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/mocks/oslpdevice/MockOslpServer.java
@@ -36,10 +36,6 @@ import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.opensmartgridplatform.adapter.protocol.oslp.elster.infra.messaging.DeviceRequestMessageType;
 import org.opensmartgridplatform.cucumber.core.Wait;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.opensmartgridplatform.cucumber.platform.config.CoreDeviceConfiguration;
@@ -78,7 +74,11 @@ import org.opensmartgridplatform.oslp.OslpDecoder;
 import org.opensmartgridplatform.oslp.OslpEncoder;
 import org.opensmartgridplatform.oslp.OslpEnvelope;
 import org.opensmartgridplatform.oslp.OslpUtils;
+import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.security.CertificateHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
@@ -118,8 +118,8 @@ public class MockOslpServer {
     // TODO split channel handler in client/server
     private MockOslpChannelHandler channelHandler;
 
-    private final ConcurrentMap<DeviceRequestMessageType, Message> mockResponses = new ConcurrentHashMap<>();
-    private final ConcurrentMap<DeviceRequestMessageType, Message> receivedRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<MessageType, Message> mockResponses = new ConcurrentHashMap<>();
+    private final ConcurrentMap<MessageType, Message> receivedRequests = new ConcurrentHashMap<>();
     private final List<Message> receivedResponses = new ArrayList<>();
 
     public MockOslpServer(final CoreDeviceConfiguration configuration, final int oslpPortServer,
@@ -182,7 +182,7 @@ public class MockOslpServer {
         this.channelHandler.reset();
     }
 
-    public Message waitForRequest(final DeviceRequestMessageType requestType) {
+    public Message waitForRequest(final MessageType requestType) {
         int count = 0;
         while (!this.receivedRequests.containsKey(requestType)) {
             try {
@@ -363,47 +363,47 @@ public class MockOslpServer {
             builder.setOsgpPortNumber(osgpPort);
         }
 
-        this.mockResponses.put(DeviceRequestMessageType.GET_CONFIGURATION,
+        this.mockResponses.put(MessageType.GET_CONFIGURATION,
                 Oslp.Message.newBuilder().setGetConfigurationResponse(builder).build());
     }
 
     public void mockSetConfigurationResponse(final Oslp.Status oslpStatus) {
 
-        this.mockResponses.put(DeviceRequestMessageType.SET_CONFIGURATION, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.SET_CONFIGURATION, Oslp.Message.newBuilder()
                 .setSetConfigurationResponse(SetConfigurationResponse.newBuilder().setStatus(oslpStatus).build())
                 .build());
     }
 
     public void mockGetFirmwareVersionResponse(final String fwVersion) {
-        this.mockResponses.put(DeviceRequestMessageType.GET_FIRMWARE_VERSION, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.GET_FIRMWARE_VERSION, Oslp.Message.newBuilder()
                 .setGetFirmwareVersionResponse(GetFirmwareVersionResponse.newBuilder().setFirmwareVersion(fwVersion))
                 .build());
     }
 
     public void mockUpdateFirmwareResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.UPDATE_FIRMWARE, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.UPDATE_FIRMWARE, Oslp.Message.newBuilder()
                 .setUpdateFirmwareResponse(UpdateFirmwareResponse.newBuilder().setStatus(status)).build());
     }
 
     public void mockSetLightResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.SET_LIGHT,
+        this.mockResponses.put(MessageType.SET_LIGHT,
                 Oslp.Message.newBuilder().setSetLightResponse(SetLightResponse.newBuilder().setStatus(status)).build());
     }
 
     public void mockSetEventNotificationResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.SET_EVENT_NOTIFICATIONS,
+        this.mockResponses.put(MessageType.SET_EVENT_NOTIFICATIONS,
                 Oslp.Message.newBuilder()
                         .setSetEventNotificationsResponse(SetEventNotificationsResponse.newBuilder().setStatus(status))
                         .build());
     }
 
     public void mockStartDeviceResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.START_SELF_TEST, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.START_SELF_TEST, Oslp.Message.newBuilder()
                 .setStartSelfTestResponse(StartSelfTestResponse.newBuilder().setStatus(status)).build());
     }
 
     public void mockStopDeviceResponse(final com.google.protobuf.ByteString value, final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.STOP_SELF_TEST, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.STOP_SELF_TEST, Oslp.Message.newBuilder()
                 .setStopSelfTestResponse(StopSelfTestResponse.newBuilder().setSelfTestResult(value).setStatus(status))
                 .build());
     }
@@ -423,27 +423,27 @@ public class MockOslpServer {
             response.addValue(tariffValue);
         }
 
-        this.mockResponses.put(DeviceRequestMessageType.GET_STATUS,
+        this.mockResponses.put(MessageType.GET_STATUS,
                 Oslp.Message.newBuilder().setGetStatusResponse(response).build());
     }
 
     public void mockResumeScheduleResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.RESUME_SCHEDULE, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.RESUME_SCHEDULE, Oslp.Message.newBuilder()
                 .setResumeScheduleResponse(ResumeScheduleResponse.newBuilder().setStatus(status)).build());
     }
 
     public void mockSetRebootResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.SET_REBOOT, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.SET_REBOOT, Oslp.Message.newBuilder()
                 .setSetRebootResponse(SetRebootResponse.newBuilder().setStatus(status)).build());
     }
 
     public void mockSetTransitionResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.SET_TRANSITION, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.SET_TRANSITION, Oslp.Message.newBuilder()
                 .setSetTransitionResponse(SetTransitionResponse.newBuilder().setStatus(status)).build());
     }
 
     public void mockUpdateKeyResponse(final Oslp.Status status) {
-        this.mockResponses.put(DeviceRequestMessageType.UPDATE_KEY, Oslp.Message.newBuilder()
+        this.mockResponses.put(MessageType.UPDATE_KEY, Oslp.Message.newBuilder()
                 .setSetDeviceVerificationKeyResponse(SetDeviceVerificationKeyResponse.newBuilder().setStatus(status))
                 .build());
     }
@@ -458,63 +458,13 @@ public class MockOslpServer {
             response.addValue(lightValue);
         }
 
-        this.mockResponses.put(DeviceRequestMessageType.GET_LIGHT_STATUS,
+        this.mockResponses.put(MessageType.GET_LIGHT_STATUS,
                 Oslp.Message.newBuilder().setGetStatusResponse(response).build());
     }
 
-    public void mockSetScheduleResponse(final DeviceRequestMessageType type, final Oslp.Status status) {
+    public void mockSetScheduleResponse(final MessageType type, final Oslp.Status status) {
         this.mockResponses.put(type, Oslp.Message.newBuilder()
                 .setSetScheduleResponse(SetScheduleResponse.newBuilder().setStatus(status)).build());
-    }
-
-    public void mockGetActualPowerUsageResponse(final Oslp.Status status, final Integer actualConsumedPower,
-            final MeterType meterType, final String recordTime, final Integer totalConsumedEnergy,
-            final Integer totalLightingHours, final Integer actualCurrent1, final Integer actualCurrent2,
-            final Integer actualCurrent3, final Integer actualPower1, final Integer actualPower2,
-            final Integer actualPower3, final Integer averagePowerFactor1, final Integer averagePowerFactor2,
-            final Integer averagePowerFactor3, final String relayData) {
-
-        final org.opensmartgridplatform.oslp.Oslp.SsldData.Builder ssldData = SsldData.newBuilder();
-
-        if (relayData != null && !relayData.isEmpty()) {
-            for (final String data : relayData.split(PlatformKeys.SEPARATOR_SEMICOLON)) {
-                final String[] dataParts = data.split(PlatformKeys.SEPARATOR_COMMA);
-
-                final RelayData r = RelayData.newBuilder()
-                        .setIndex(OslpUtils.integerToByteString(Integer.parseInt(dataParts[0])))
-                        .setTotalLightingMinutes(Integer.parseInt(dataParts[1])).build();
-                ssldData.addRelayData(r);
-            }
-        }
-
-        final org.opensmartgridplatform.oslp.Oslp.PowerUsageData.Builder powerUsageData = PowerUsageData.newBuilder();
-
-        if (meterType != null) {
-            powerUsageData.setMeterType(meterType);
-        }
-
-        if (totalLightingHours != null) {
-            powerUsageData.setPsldData(PsldData.newBuilder().setTotalLightingHours(totalLightingHours).build());
-        }
-
-        if (!recordTime.isEmpty()) {
-            powerUsageData.setRecordTime(recordTime);
-        }
-
-        final org.opensmartgridplatform.oslp.Oslp.GetActualPowerUsageResponse response = org.opensmartgridplatform.oslp.Oslp.GetActualPowerUsageResponse
-                .newBuilder().setStatus(status)
-                .setPowerUsageData(powerUsageData.setActualConsumedPower(actualConsumedPower)
-                        .setTotalConsumedEnergy(totalConsumedEnergy)
-                        .setSsldData(ssldData.setActualCurrent1(actualCurrent1).setActualCurrent2(actualCurrent2)
-                                .setActualCurrent3(actualCurrent3).setActualPower1(actualPower1)
-                                .setActualPower2(actualPower2).setActualPower3(actualPower3)
-                                .setAveragePowerFactor1(averagePowerFactor1).setAveragePowerFactor2(averagePowerFactor2)
-                                .setAveragePowerFactor3(averagePowerFactor3).build())
-                        .build())
-                .build();
-
-        this.mockResponses.put(DeviceRequestMessageType.GET_ACTUAL_POWER_USAGE,
-                Oslp.Message.newBuilder().setGetActualPowerUsageResponse(response).build());
     }
 
     public void mockGetPowerUsageHistoryResponse(final Oslp.Status status, final Map<String, String[]> requestMap) {
@@ -533,7 +483,7 @@ public class MockOslpServer {
             response = builder.setStatus(status).build();
         }
 
-        this.mockResponses.put(DeviceRequestMessageType.GET_POWER_USAGE_HISTORY,
+        this.mockResponses.put(MessageType.GET_POWER_USAGE_HISTORY,
                 Oslp.Message.newBuilder().setGetPowerUsageHistoryResponse(response).build());
     }
 


### PR DESCRIPTION
Updates mock objects to use MessageType values instead of
DeviceRequestMessageType values.

Removes mocking and step implementations of the unused
GetActualPowerUsage message type.